### PR TITLE
[#33] Gitea dump script not running daily

### DIFF
--- a/playbooks/roles/gitea_backup/templates/gitea_dump.sh.j2
+++ b/playbooks/roles/gitea_backup/templates/gitea_dump.sh.j2
@@ -2,6 +2,9 @@
 # Exit on error, treat unset variables as an error, and propagate exit codes through pipes.
 set -euo pipefail
 
+# Set the PATH to ensure Docker is found, based on interactive shell on Synology NAS
+export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/syno/sbin:/usr/syno/bin:/usr/local/sbin:/usr/local/bin
+
 # --- Variables ---
 GITEA_CONTAINER_NAME="{{ gitea_container_name | default('gitea') }}"
 GITEA_USER_ID="1000" # The UID of the user inside the container


### PR DESCRIPTION
### Description of Changes

<!-- A brief summary of what was changed and why. -->
Added full PATH to script so `docker` can be found and nightly backups of Gitea don't fail.

### Related Issue

<!-- Link to the issue that this PR resolves. -->

Closes #33

### Self-Check

- [x] I have tested these changes locally (e.g., using `make act-test` or by running the playbook directly).
- [x] I have updated the documentation if necessary.