### PR TITLE
Add SSH git support via Tailscale Serve TCP forward

### DIFF
--- a/playbooks/gitea-deploy.yml
+++ b/playbooks/gitea-deploy.yml
@@ -68,6 +68,9 @@
         tailscale_serve_config_dir: "{{ tailscale_gitea_serve_config_dir }}"
         tailscale_serve_domain: "{{ gitea_domain }}"
         tailscale_serve_proxy_port: "3000"
+        tailscale_serve_ssh_enabled: true
+        tailscale_serve_ssh_forward_host: "127.0.0.1"
+        tailscale_serve_ssh_forward_port: "{{ gitea_ssh_port }}"
         tailscale_host_ports:
           - "127.0.0.1:{{ gitea_port }}:3000"
 

--- a/playbooks/roles/tailscale_sidecar/templates/ts-serve-gitea.json.j2
+++ b/playbooks/roles/tailscale_sidecar/templates/ts-serve-gitea.json.j2
@@ -2,7 +2,10 @@
   "TCP": {
     "443": {
       "HTTPS": true
-    }
+    }{% if tailscale_serve_ssh_enabled | default(false) | bool %},
+    "22": {
+      "TCPForward": "{{ tailscale_serve_ssh_forward_host | default('127.0.0.1') }}:{{ tailscale_serve_ssh_forward_port | default('22') }}"
+    }{% endif %}
   },
   "Web": {
     "{{ tailscale_serve_domain }}:443": {


### PR DESCRIPTION
## Summary

- Extends `ts-serve-gitea.json.j2` to conditionally add a TCP port 22 forward alongside the existing HTTPS 443 proxy
- Enabled by passing `tailscale_serve_ssh_enabled: true` in the Gitea sidecar role invocation in \`gitea-deploy.yml\`
- Forwards to \`127.0.0.1:{{ gitea_ssh_port }}\` (port 22) — safe because the Tailscale container shares Gitea's network namespace

## How it works

Tailscale Serve's \`TCPForward\` passes raw bytes through without TLS termination, which is exactly what SSH requires — the client's key negotiation reaches Gitea unmodified.

After deployment, SSH git access works as:
\`\`\`
git clone git@gitea.<tailnet>.ts.net:user/repo.git
\`\`\`

## Test plan

- [ ] Deploy and verify \`tailscale debug serve-config\` inside the container shows both port 443 and port 22
- [ ] Confirm \`git clone ssh://git@gitea.<tailnet>.ts.net/user/repo.git\` succeeds from another tailnet device
- [ ] Confirm HTTPS access on 443 is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)