### PR TITLE
feat(gitea): healthchecks + depends_on-equivalent gate

### DIFF
--- a/playbooks/roles/gitea_server/tasks/main.yml
+++ b/playbooks/roles/gitea_server/tasks/main.yml
@@ -32,7 +32,14 @@
     state: present
 
 - name: Deploy MySQL container for Gitea
-  # Launch a MySQL container for the Gitea database
+  # Launch a MySQL container for the Gitea database.
+  #
+  # The healthcheck is load-bearing: without it, a silent mysqld death inside
+  # the container leaves the container "Up" while gitea fails to connect
+  # indefinitely. With it, Docker marks the container unhealthy and the
+  # restart_policy=always brings it back. Observed 2026-05-02: after an
+  # unclean shutdown of the host, mysqld completed InnoDB recovery and then
+  # exited silently; container stayed "Up 13min" with no listener on 3306.
   community.docker.docker_container:
     name: gitea-db
     image: "{{ gitea_db_image }}"
@@ -50,6 +57,24 @@
     volumes:
       - "{{ gitea_data_path }}/db:/var/lib/mysql"
     command: "--character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci"
+    healthcheck:
+      test:
+        - "CMD"
+        - "mysqladmin"
+        - "ping"
+        - "-h"
+        - "127.0.0.1"
+        - "-u"
+        - "root"
+        - "-p{{ gitea_db_password }}"
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      # Allow up to 10 minutes for InnoDB crash recovery on a dirty restart.
+      # Real-world observation 2026-05-02: 4-minute recovery on a moderately
+      # active DB. Longer-than-real budget here so the container isn't marked
+      # unhealthy while it's legitimately recovering.
+      start_period: 10m
   tags: db
 
 - name: Check if internal token file exists
@@ -100,7 +125,32 @@
     mode: '0640'
   notify: Restart Gitea
 
-# --- Gitea container deployment (conditional on Tailscale) ---
+# --- Wait for MySQL to be healthy BEFORE deploying Gitea --------------------
+# This is the ansible equivalent of compose `depends_on: { condition:
+# service_healthy }`. It polls Docker for the gitea-db container's health
+# status (set by the `healthcheck:` configured above) and only proceeds once
+# Docker marks it healthy. Without this gate, gitea starts before mysqld is
+# accepting connections and burns through its built-in 30-second retry budget,
+# entering a restart loop.
+- name: Wait for gitea-db to be healthy
+  community.docker.docker_container_info:
+    name: gitea-db
+  register: gitea_db_info
+  until: >
+    gitea_db_info.container is defined
+    and gitea_db_info.container.State.Health is defined
+    and gitea_db_info.container.State.Health.Status == "healthy"
+  # 60 retries × 10s = 10 minutes. Matches the start_period budget of the
+  # healthcheck so InnoDB recovery has full time to complete.
+  retries: 60
+  delay: 10
+  when: not ansible_check_mode
+  tags: db
+
+# --- Gitea container deployment (conditional on Tailscale) -----------------
+# Both variants get an HTTP healthcheck on the local listener so Docker can
+# detect a dead gitea process even when the container's PID 1 (entrypoint
+# shell) is still alive.
 
 - name: Deploy Gitea container (with Tailscale sidecar)
   community.docker.docker_container:
@@ -116,6 +166,12 @@
       - "{{ gitea_data_path }}/gitea:/var/lib/gitea"
       - "{{ gitea_app_ini_path_host }}:{{ gitea_app_ini_path_container }}"
       - "{{ gitea_data_path }}/conf/secrets:/etc/gitea/secrets:ro"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null --timeout=5 http://127.0.0.1:3000/ || exit 1"]
+      interval: 30s
+      timeout: 8s
+      retries: 3
+      start_period: 2m
   when: tailscale_enabled | default(false) | bool
   tags: gitea
   notify: Restart Gitea
@@ -141,19 +197,29 @@
       - "{{ gitea_app_ini_path_host }}:{{ gitea_app_ini_path_container }}"
       - "{{ gitea_data_path }}/conf/secrets:/etc/gitea/secrets:ro"
       - "{{ certbot_data_path }}/certs:/etc/letsencrypt:ro"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null --timeout=5 http://127.0.0.1:3000/ || exit 1"]
+      interval: 30s
+      timeout: 8s
+      retries: 3
+      start_period: 2m
   when: not (tailscale_enabled | default(false) | bool)
   tags: gitea
   notify: Restart Gitea
 
+# Defense-in-depth: still verify TCP from inside gitea after deploy. The
+# pre-deploy `Wait for gitea-db to be healthy` task should make this a no-op,
+# but keeping it catches the edge case where gitea-db became healthy then
+# immediately died between the wait and the gitea start.
 - name: Wait for MySQL to be ready (from within Gitea container)
   community.docker.docker_container_exec:
     container: gitea
     command: nc -z gitea-db 3306
   register: db_check_result
   until: db_check_result.rc is defined and db_check_result.rc == 0
-  retries: 15          # Try 15 times
-  delay: 5             # Wait 5 seconds between retries (total wait time: 75s)
-  changed_when: false  # This task just checks status, it doesn't make a change
+  retries: 15
+  delay: 5
+  changed_when: false
   when: not ansible_check_mode
 
 - block:


### PR DESCRIPTION
## Summary

Adds container healthchecks to `gitea-db` and `gitea`, plus an explicit "wait for gitea-db to be healthy" task before deploying gitea (the ansible equivalent of compose `depends_on: { condition: service_healthy }`).

## Why

On 2026-05-02 an unclean NAS shutdown left `mysqld` in `gitea-db` in a state where it completed InnoDB recovery, then exited silently. Docker's view was still "Up 13min" because the entrypoint shell (PID 1) was alive, but nothing was listening on port 3306. With no healthcheck, `restart_policy: always` had nothing to react to. Gitea, meanwhile, kept restarting because its built-in 30-second DB connection retry budget was exhausted on every cycle (real recovery took ~4 min).

## Changes

1. **`gitea-db` healthcheck** — `mysqladmin ping`, `start_period: 10m` to cover worst-observed InnoDB recovery (~4 min). When mysqld dies inside the container, Docker marks it unhealthy → `restart_policy: always` recreates it.
2. **New "Wait for gitea-db to be healthy" task** before gitea deploy. Polls Docker for `State.Health.Status == "healthy"` with 60 retries × 10s = 10 min budget. Ansible-side equivalent of compose's `depends_on: { condition: service_healthy }`.
3. **`gitea` healthcheck** (both tailscale-sidecar and standalone variants) — HTTP check against `127.0.0.1:3000`. Detects a dead gitea process even if the container's PID 1 (entrypoint shell) is still alive.
4. **Kept the existing post-deploy MySQL TCP check** as defense-in-depth — no-op in the common case, catches the edge case where `gitea-db` became healthy then immediately died between the gate and the gitea start.

## Test plan

- [ ] Run `ansible-playbook playbooks/gitea-deploy.yml` against a host where the existing gitea is already deployed and healthy → expect no changes (idempotent on healthy state)
- [ ] Run against the NAS while gitea-db is intentionally killed → expect Docker to mark it unhealthy and the playbook to wait until it recovers
- [ ] Verify `docker inspect gitea-db --format '{{.State.Health.Status}}'` returns `healthy` after a clean run
- [ ] Verify `docker inspect gitea --format '{{.State.Health.Status}}'` returns `healthy` after a clean run

## Related

- Diagnostic bundle from 2026-05-02 incident: `~/cache-diag-2026-05-02.tar.gz` on the gaming host
- Synology support ticket draft: `~/synology-support-case-draft.md` on the gaming host

🤖 Generated with [Claude Code](https://claude.com/claude-code)