### PR TITLE
feat(gitea-runner): healthcheck detects s6 init wedge

### DIFF
--- a/playbooks/roles/gitea_runner/tasks/main.yml
+++ b/playbooks/roles/gitea_runner/tasks/main.yml
@@ -62,6 +62,19 @@
 
 # --- Runner container deployment (conditional on Tailscale) ---
 
+# Healthcheck used by both deploy variants below. Detects the s6 init wedge
+# observed 2026-05-02 after a NAS dirty restart: dockerd inside the runner
+# came up, but s6 didn't fire its docker-ready signal, so act_runner stayed
+# blocked on `s6-svwait -U /etc/s6/docker` and never started polling. Docker
+# saw the container as "Up" the whole time. The healthcheck below greps
+# /proc for an act_runner process; if missing, Docker marks unhealthy and
+# `restart_policy: always` recreates the container (which re-runs s6 init,
+# usually clean the second time).
+#
+# We can't `pgrep act_runner` because the dind image doesn't ship pgrep —
+# fall back to `grep -q act_runner /proc/*/comm`. The `[a]` trick avoids
+# matching the grep itself.
+
 - name: Deploy Gitea runner container (with Tailscale sidecar)
   community.docker.docker_container:
     name: gitea-runner
@@ -78,6 +91,12 @@
       DOCKER_INSECURE_NO_IPTABLES_RAW: "1" # needed for Docker-in-Docker on the Synology DSM which does not include iptables_raw kernel module
     volumes:
       - "{{ gitea_runner_data_path }}:/data"
+    healthcheck:
+      test: ["CMD-SHELL", "grep -q act_runner /proc/[0-9]*/comm 2>/dev/null || exit 1"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 2m
   when: tailscale_enabled | default(false) | bool
 
 - name: Deploy Gitea runner container (standalone)
@@ -101,4 +120,10 @@
       DOCKER_INSECURE_NO_IPTABLES_RAW: "1" # needed for Docker-in-Docker on the Synology DSM which does not include iptables_raw kernel module
     volumes:
       - "{{ gitea_runner_data_path }}:/data"
+    healthcheck:
+      test: ["CMD-SHELL", "grep -q act_runner /proc/[0-9]*/comm 2>/dev/null || exit 1"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 2m
   when: not (tailscale_enabled | default(false) | bool)


### PR DESCRIPTION
## Summary

Adds a Docker healthcheck to the `gitea-runner` container (both deploy variants). Detects the s6 init wedge observed 2026-05-02 after a NAS dirty restart.

## What happened tonight

After the NAS power cycle, `gitea-runner` came up showing `Up 1 hour` in `docker ps`. But internally:

```
PID 1   s6-svscan /etc/s6
PID 7   s6-supervise act_runner
PID 8   s6-supervise docker
PID 9   bash ./run act_runner   ← stuck in do_wait on s6-svwait -U /etc/s6/docker
PID 10+ docker-init/dockerd/containerd  ← all running
```

The runner's s6 init script `/etc/s6/act_runner/run` does:

```bash
s6-svwait -U /etc/s6/docker
exec run.sh
```

After a dirty restart, dockerd came up, but s6's "service ready" signal didn't fire on the docker service. So `act_runner` never started polling, queued workflow_dispatch jobs sat in "queued" state for 5+ minutes, and Docker had no idea anything was wrong. Manual `docker restart gitea-runner` was needed.

## Fix

Adds:

```yaml
healthcheck:
  test: ["CMD-SHELL", "grep -q act_runner /proc/[0-9]*/comm 2>/dev/null || exit 1"]
  interval: 60s
  timeout: 5s
  retries: 3
  start_period: 2m
```

When `act_runner` is missing from `/proc`, Docker marks the container unhealthy. Combined with the existing `restart_policy: always`, this triggers a recreation. The s6 init usually succeeds cleanly on the second attempt.

`grep -q act_runner /proc/*/comm` instead of `pgrep` because the dind base image doesn't ship `pgrep`.

`start_period: 2m` covers normal init time so we don't false-fail during startup.

## Test plan

- [ ] Merge → next ansible deploy applies the healthcheck (container will recreate to pick it up)
- [ ] After deploy: `docker inspect gitea-runner --format '{{.State.Health.Status}}'` returns `healthy`
- [ ] Force the failure: `docker exec gitea-runner pkill -9 act_runner` → wait ~3 min → expect `Health.Status=unhealthy` then container restart
- [ ] Verify: `docker logs gitea-runner --tail 5` shows fresh s6 startup messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)