### PR TITLE
fix(gitea_runner): bind-mount certs into job containers (iter 2)

### DIFF
--- a/playbooks/roles/gitea_runner/templates/config.yaml.j2
+++ b/playbooks/roles/gitea_runner/templates/config.yaml.j2
@@ -69,13 +69,18 @@ container:
   privileged: true
   # And other options to be used when the container is started (eg, --add-host=my.gitea.url:host-gateway).
   # Expose this runner's embedded dind dockerd to every job container:
-  # - Share the dind TLS client certs (written by docker-init into the
-  #   gitea-runner-certs named volume at /certs) read-only into the job
+  # - Bind-mount /certs/client (read-only) so the job's docker CLI has the
+  #   TLS client cert+key dind expects. Bind mount instead of named volume
+  #   because dind dockerd maintains its own volume namespace separate from
+  #   the host's — `-v gitea-runner-certs:/certs` would resolve to an empty
+  #   volume in dind. The bind source resolves on dind dockerd's filesystem
+  #   (which is the gitea-runner container), where /certs is the host-mounted
+  #   named volume populated by docker-init at runner startup.
   # - Map "docker" hostname to the host gateway, which (from inside a job
-  #   container spawned by the dind dockerd) resolves to the dockerd itself
-  # - Inject DOCKER_HOST/TLS env vars so docker CLI in jobs connects with TLS
+  #   container spawned by the dind dockerd) resolves to the dockerd itself.
+  # - Inject DOCKER_HOST/TLS env vars so docker CLI in jobs connects with TLS.
   # See fallen-leaf/ansible-runner-image#1.
-  options: "-v gitea-runner-certs:/certs:ro --add-host=docker:host-gateway -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client"
+  options: "-v /certs/client:/certs/client:ro --add-host=docker:host-gateway -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client"
   # The parent directory of a job's working directory.
   # NOTE: There is no need to add the first '/' of the path as act_runner will add it automatically.
   # If the path starts with '/', the '/' will be trimmed.


### PR DESCRIPTION
## Summary

Second-iteration fix for `fallen-leaf/ansible-runner-image#1` after PR #79's first-pass failed empirically.

## What was wrong with PR #79

PR #79 used `-v gitea-runner-certs:/certs:ro` in `container.options`. Looked right, but job containers reported:

```
unable to resolve docker endpoint: open /certs/client/ca.pem: no such file or directory
```

**Root cause**: dind dockerd maintains its own named-volume namespace, separate from the host's. When act_runner asks dind dockerd to spawn a job with `-v gitea-runner-certs:/certs`, dind resolves the name in its OWN namespace, finds nothing, auto-creates an empty volume, and mounts that into the job. The job sees no certs even though the host-side volume is populated.

This is a dind-specific gotcha that only surfaces empirically — the deploy succeeded, the job container started, certs just weren't there.

## Fix

Switch from named-volume reference to bind mount: `-v /certs/client:/certs/client:ro`.

Bind mount sources resolve on the dind dockerd's filesystem — which is the gitea-runner container's filesystem — where `/certs` is the host-mounted named volume populated by `docker-init`. Bind mounts cross the dind boundary; named-volume names don't.

Also narrowed from `/certs` to `/certs/client` — job containers only need the client cert+key, not the dind server cert.

## What this PR does NOT change

- The named-volume mount on the gitea-runner container itself (`gitea-runner-certs:/certs` in `tasks/main.yml`) stays. That mount IS host-resolved (ansible-managed by host docker), so it's fine. It also lets dind certs persist across runner restarts.
- All other env vars + `--add-host=docker:host-gateway` + DOCKER_HOST/TLS settings stay.

## Verification path (after merge + deploy)

1. Ansible re-renders the config and restart handler recreates the runner
2. Re-trigger `fallen-leaf/ansible-runner-image` `Build and Push ansible-runner image` workflow
3. Expected: `Set up Docker Buildx` passes; build + push complete; image lands in registry

If a third iteration is needed (e.g., `--add-host=docker:host-gateway` doesn't resolve correctly, or cert SAN mismatch), the symptom would be a TLS handshake error, not the cert-not-found error from iter 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)