### PR TITLE
feat(gitea_runner): userspace Tailscale sidecar + multi-network runner

### DIFF
--- a/.github/workflows/common-bootstrap.yml
+++ b/.github/workflows/common-bootstrap.yml
@@ -23,6 +23,7 @@ jobs:
       GITEA_DB_PASSWORD: ${{ secrets.GITEA_DB_PASSWORD || secrets.MYGITEA_DB_PASSWORD }}
       GITEA_LAN_HOST: ${{ secrets.GITEA_LAN_HOST || secrets.MYGITEA_LAN_HOST }}
       GITEA_LAN_SSH_PORT: ${{ secrets.GITEA_LAN_SSH_PORT || secrets.MYGITEA_LAN_SSH_PORT }}
+      LAN_DOMAIN_SUFFIX: ${{ secrets.LAN_DOMAIN_SUFFIX }}
       GITEA_RESTORE: ${{ inputs.recover }}
       B2_APPLICATION_KEY_ID: ${{ secrets.B2_APPLICATION_KEY_ID }}
       B2_APPLICATION_KEY: ${{ secrets.B2_APPLICATION_KEY }}

--- a/README.md
+++ b/README.md
@@ -136,9 +136,15 @@ Gitea and the Gitea Actions runner are each paired with a [Tailscale](https://ta
 
 ### How It Works
 
-Each application container shares its network namespace with a `tailscale/tailscale` sidecar container using Docker's `network_mode: container:` option. The sidecar handles Tailscale connectivity while the application runs its services as if they were local. Both sidecars are placed on the `gitea-net` Docker bridge network, which allows Gitea to reach MySQL (`gitea-db:3306`) while keeping MySQL itself off the tailnet entirely.
+The two sidecars use **different Tailscale networking modes** because their workloads have different network needs. See [docs/architecture/tailscale-sidecar-modes.md](docs/architecture/tailscale-sidecar-modes.md) for the deep dive.
 
-[Tailscale Serve](https://tailscale.com/kb/1312/serve) provides HTTPS on the tailnet for Gitea — it terminates TLS with a Tailscale-managed certificate and proxies to Gitea's HTTP port inside the shared network namespace. Gitea itself runs plain HTTP internally; all HTTPS for the tailnet is handled by Tailscale Serve.
+**Gitea sidecar (kernel-mode, namespace-shared):**
+Gitea shares its network namespace with the `tailscale-gitea` sidecar via Docker's `network_mode: container:` option. The sidecar handles Tailscale connectivity, and [Tailscale Serve](https://tailscale.com/kb/1312/serve) terminates TLS for `https://gitea.<your-tailnet>` with a Tailscale-managed certificate, proxying to Gitea's HTTP port inside the shared namespace. Gitea itself runs plain HTTP internally; all HTTPS for the tailnet is handled by Tailscale Serve. Kernel mode is required here because Tailscale Serve depends on the kernel TUN device.
+
+**Runner sidecar (userspace-mode, multi-network):**
+The `gitea-runner` sits on the same `gitea-net` Docker bridge as the `tailscale-runner` sidecar — NOT in its namespace. This gives `gitea-runner` (and the dind dockerd it embeds) full LAN access through the host's networking stack, which is essential for job containers that need to reach LAN destinations (UniFi controller, NAS DNS, etc.). The runner reaches the tailnet through the sidecar's HTTP-CONNECT/SOCKS5 proxy via `HTTPS_PROXY=http://tailscale-runner:1099` / `ALL_PROXY=socks5://tailscale-runner:1055`. The sidecar runs Tailscale in [userspace networking mode](https://tailscale.com/kb/1112/userspace-networking) to expose those proxy ports to its peers.
+
+Both sidecars sit on `gitea-net`, which keeps MySQL (`gitea-db:3306`) reachable from Gitea while staying off the tailnet entirely.
 
 ### Using This Repo as a Template
 

--- a/README.md
+++ b/README.md
@@ -206,10 +206,11 @@ In GitHub (Settings → Secrets and variables → Actions → Secrets):
 | `GITEA_DB_PASSWORD`     | Gitea Database Password                                                |
 | `GITEA_LAN_HOST`        | LAN-facing host/IP for Gitea (topology). On Gitea side, store under the alias `MYGITEA_LAN_HOST` — the `GITEA_*` prefix is reserved by Gitea Actions. |
 | `GITEA_LAN_SSH_PORT`    | LAN port for Gitea SSH (defaults to `2222` if unset). On Gitea side, store under the alias `MYGITEA_LAN_SSH_PORT` — same reservation. |
+| `LAN_DOMAIN_SUFFIX`     | LAN DNS suffix used for `NO_PROXY` exemption inside the Gitea Actions runner so LAN hostnames bypass the userspace tailnet proxy (topology). Include the leading dot, e.g. `.lan.example.com`. |
 | `TS_AUTHKEY`            | Tailscale auth key (reusable, non-ephemeral)                           |
 | `TS_TAILNET`            | Tailscale tailnet domain, e.g. `your-tailnet.ts.net` (topology secret) |
 
-> Topology values (`NAS_HOST`, `NAS_SSH_USER`, `LAN_DNS`, `TS_TAILNET`, `GITEA_LAN_HOST`) are stored as Secrets — not Variables — because Actions Variables are not redacted in workflow logs and this repo is mirrored to a public GitHub presence. See issue #6.
+> Topology values (`NAS_HOST`, `NAS_SSH_USER`, `LAN_DNS`, `TS_TAILNET`, `GITEA_LAN_HOST`, `LAN_DOMAIN_SUFFIX`) are stored as Secrets — not Variables — because Actions Variables are not redacted in workflow logs and this repo is mirrored to a public GitHub presence. See issue #6.
 >
 > Gitea Actions reserves the `GITEA_*` prefix for system context variables. Repo-level Secrets in that namespace are rejected by the API. Plan #1's new Secrets (`GITEA_LAN_HOST`, `GITEA_LAN_SSH_PORT`) use the existing repo convention: store under the `MYGITEA_*` alias on Gitea, keep `GITEA_*` on GitHub, and the workflow falls back across both via `${{ secrets.GITEA_X || secrets.MYGITEA_X }}` (mirrors the existing `GITEA_ADMIN_USERNAME` / `MYGITEA_ADMIN_USERNAME` pattern).
 

--- a/README.md
+++ b/README.md
@@ -65,12 +65,13 @@ Makefile                        # Makefile for common tasks
 flowchart TB
     subgraph Tailnet["Tailscale Tailnet"]
         TG_TS["tailscale-gitea<br/>(TS_SERVE: HTTPS → HTTP :3000)"]
-        TR_TS["tailscale-runner<br/>(tailnet access only)"]
+        TR_TS["tailscale-runner<br/>(userspace mode, exposes :1055 SOCKS5 / :1099 HTTP CONNECT)"]
     end
     subgraph DockerNet["gitea-net (Docker Bridge)"]
         TG_TS --- |"network_mode: container"| Gitea["gitea<br/>(HTTP :3000, SSH :22)"]
         DB["gitea-db<br/>(MySQL :3306)"]
-        TR_TS --- |"network_mode: container"| Runner["gitea-runner<br/>(Act Runner)"]
+        Runner["gitea-runner<br/>(Act Runner)"] --- |"on gitea-net"| TR_TS
+        Runner -.->|"HTTPS_PROXY :1099"| TR_TS
     end
     Gitea --> |"gitea-db:3306"| DB
     Runner --> |"https://gitea.tailnet"| TG_TS

--- a/docs/architecture/tailscale-sidecar-modes.md
+++ b/docs/architecture/tailscale-sidecar-modes.md
@@ -1,0 +1,116 @@
+# Tailscale Sidecar Networking Modes
+
+## Context
+
+This repo deploys two Tailscale sidecars: one in front of Gitea, one in front of the Gitea Actions runner. They look symmetric, but they use **two different Tailscale networking modes** because their service profiles are different. The choice has non-obvious blast radius: when in doubt, the wrong choice usually shows up as "containers can reach tailnet but not LAN" — or vice versa.
+
+This doc captures the trade-off so future reviewers don't have to re-discover it.
+
+## The two modes
+
+### Kernel mode + `network_mode: container:<sidecar>`
+
+```
+┌──────────────────────────────────────────────┐
+│ Sidecar's network namespace                  │
+│                                              │
+│   tailscale0 (kernel TUN, from Tailscale)    │
+│   eth0      (Docker bridge attachment)       │
+│   lo                                         │
+│                                              │
+│  ┌────────────────────┐  ┌─────────────────┐ │
+│  │ tailscale-gitea    │  │ gitea           │ │
+│  │ (sidecar process)  │  │ (consumer; uses │ │
+│  │                    │  │  this namespace │ │
+│  │                    │  │  via network_   │ │
+│  │                    │  │  mode:container)│ │
+│  └────────────────────┘  └─────────────────┘ │
+└──────────────────────────────────────────────┘
+```
+
+**Profile:**
+- The sidecar binds a kernel `TUN` device (`/dev/net/tun`) and runs Tailscale in kernel mode.
+- The consumer container joins via `network_mode: container:<sidecar-name>`, sharing the namespace exactly.
+- Both processes see the same interfaces: `tailscale0`, the Docker bridge attachment, and loopback.
+- Tailscale Serve, Tailscale SSH, exit-node, subnet-router — all the kernel-feature stuff — works here.
+
+**Trade-off:**
+- Consumer's outbound traffic is filtered through the sidecar's view: only what the sidecar can route is reachable.
+- LAN access depends on the Docker bridge attachment, NOT on `tailscale0`. The default route inside the namespace is the Docker bridge gateway, which routes via host → eth0 → LAN.
+- BUT: **dind-spawned child containers inherit the sidecar's namespace transitively, and dind's own auto-created bridges sit inside that namespace.** A child container's NAT chain becomes: `child → dind auto-bridge → dind gateway → sidecar namespace → bridge attachment → host → LAN`. Each hop is a NAT-translation opportunity, and the host-side iptables `FORWARD` chain has to permit the flow at every step. Synology DSM (and likely other restrictive setups) drops or fails to MASQUERADE traffic from nested-bridge subnets that aren't pre-registered with the host's firewall — and Tailscale's `tailscale0`-routed traffic bypasses that chain entirely. **Result: child containers can reach the tailnet but not the LAN.**
+
+This is exactly the failure mode that motivated this doc. See "The bug" below.
+
+### Userspace mode + standalone-network sidecar with proxy
+
+```
+┌──────────────────────────────────────────────┐
+│ gitea-net Docker bridge                      │
+│                                              │
+│  ┌────────────────────┐  ┌─────────────────┐ │
+│  │ tailscale-runner   │  │ gitea-runner    │ │
+│  │  TS_USERSPACE=true │  │  HTTPS_PROXY=   │ │
+│  │  exposes :1099 /   │◄─┤    http://      │ │
+│  │  :1055 as proxy    │  │    tailscale-   │ │
+│  │  to peers          │  │    runner:1099  │ │
+│  └────────────────────┘  └─────────────────┘ │
+│                                              │
+└──────────────────────────────────────────────┘
+        │                          │
+        │                          │
+   tailnet via                LAN via host's
+   userspace WireGuard        gitea-net → eth0
+```
+
+**Profile:**
+- Sidecar runs Tailscale in userspace networking mode (`TS_USERSPACE=true`). No kernel TUN device required.
+- Sidecar exposes Tailscale connectivity to peers via:
+  - SOCKS5 proxy on `:1055` (`TS_SOCKS5_SERVER`)
+  - HTTP CONNECT proxy on `:1099` (`TS_OUTBOUND_HTTP_PROXY_LISTEN`)
+- Consumer container sits on the same Docker bridge as the sidecar — NOT in its namespace.
+- Consumer sets `HTTPS_PROXY=http://tailscale-runner:1099` (and `ALL_PROXY=socks5://...:1055` for tools that don't speak `HTTP_PROXY`).
+- Outbound traffic to the tailnet (e.g., `gitea.<tailnet>.ts.net`) routes through the sidecar's proxy, exits the sidecar's userspace Tailscale connection.
+- Outbound traffic to anything else (LAN, internet) routes the normal Docker way: container → bridge → host → host's egress interface.
+
+**Trade-off:**
+- Loses Tailscale Serve, exit-node, and subnet-router features (those need kernel TUN).
+- Application clients must honor `HTTPS_PROXY`/`ALL_PROXY` env vars. Most modern HTTP/HTTPS clients do (Go's `net/http`, Python `requests`, `curl`, `git`, `wget`, etc.).
+- Tools that don't honor proxy env vars (some SSH clients, native protocols) won't reach the tailnet through this setup unless they're configured explicitly.
+
+## Which to use, when
+
+| Workload | Mode | Reason |
+|---|---|---|
+| Service that **publishes** to the tailnet via Tailscale Serve / SSH | Kernel + `network_mode: container:<sidecar>` | Serve/SSH need kernel TUN |
+| Service that needs **both tailnet AND LAN** access for its work | Userspace + multi-network + `HTTPS_PROXY` | Avoids the namespace-collapse LAN problem |
+| Service that needs **only LAN/internet**, no tailnet | No sidecar | Sidecar adds latency for no benefit |
+| Service that needs **only tailnet**, no LAN | Either works; kernel mode is slightly faster | Kernel mode bypasses one userspace hop |
+
+## The bug this prevented
+
+**Symptom:** A CI workflow's job container tried to resolve `unifi.lan.jaxzin.com` (a LAN hostname). DNS lookup timed out at 3 seconds. Same container could reach `100.100.100.100` (Tailscale's MagicDNS) in milliseconds.
+
+**Tracing the network state from inside the failing container:**
+
+- `/etc/resolv.conf`: `nameserver 127.0.0.11` (Docker embedded DNS) — normal.
+- Upstreams configured on the embedded DNS: `[LAN_DNS 100.100.100.100]` — correct.
+- TCP probe to LAN_DNS:53: **timeout after 3s** — packet never arrived at UniFi.
+- TCP probe to 100.100.100.100:53: **immediate connect** — Tailscale routing works.
+- TCP probe to a known-public hostname (B2): timed out at DNS resolution — same path going through LAN_DNS, same failure.
+
+**Root cause:** The runner (`gitea-runner`) shared its namespace with `tailscale-runner` via `network_mode: container:tailscale-runner`. The dind dockerd inside `gitea-runner` spawned job containers on auto-created bridges (`172.21.0.0/16`) nested inside the sidecar's namespace. The sidecar's namespace has `tailscale0` and a `gitea-net` Docker bridge attachment. Traffic to `100.x` matched a Tailscale-installed route and went via `tailscale0`. Traffic to `192.168.x.x` had to NAT through the host — but the chain of MASQUERADE rules from `dind auto-bridge → sidecar namespace → gitea-net bridge → host eth0` failed somewhere in the host's iptables `FORWARD`/`POSTROUTING` chains. Synology DSM is a likely culprit (restrictive default firewall), but the underlying issue is **the multi-hop NAT chain through a kernel-mode sidecar is fragile and OS-dependent.**
+
+**Fix:** Move the runner sidecar to userspace mode and put the runner directly on `gitea-net`. The runner now reaches the tailnet via the sidecar's `HTTPS_PROXY`, and reaches the LAN directly through the host's normal Docker → bridge → eth0 path. dind's nested auto-bridges still exist, but they sit on top of `gitea-net` (not the sidecar's namespace), so the host's MASQUERADE rule for `gitea-net → eth0` covers them.
+
+## Generalizable lesson
+
+**The `network_mode: container:<X>` pattern collapses the consumer's network to whatever `<X>` can route to.** It works beautifully for services that have a single, well-defined egress need (e.g., Gitea publishing on the tailnet via Tailscale Serve). It is a footgun for services that need multi-destination routing, especially when those services then *spawn child containers* (dind, runner job containers, nested compose stacks). In those cases, prefer userspace mode + proxy.
+
+The rule of thumb: **if a container ever needs to talk to both the tailnet AND the LAN (or even the public internet via a non-tailscale path), don't share its namespace with a kernel-mode Tailscale sidecar.**
+
+## References
+
+- [Tailscale userspace networking docs](https://tailscale.com/kb/1112/userspace-networking)
+- Diagnostic PR that surfaced this: [PR #24](https://gitea.forest-draconis.ts.net/jaxzin/jaxzin-infra-bootstrap/pulls/24) (forest-draconis Gitea instance)
+- The 4 hotfix PRs (`#20`–`#23`) that chased CI symptoms before this root cause was identified
+- Brian's `fix/gitea-runner-job-container-docker-access` (PR #79) and `fix/gitea-runner-cert-bind-mount` (PR #80) — runner config fixes that are independent of this sidecar topology fix

--- a/docs/architecture/tailscale-sidecar-modes.md
+++ b/docs/architecture/tailscale-sidecar-modes.md
@@ -108,6 +108,14 @@ This is exactly the failure mode that motivated this doc. See "The bug" below.
 
 The rule of thumb: **if a container ever needs to talk to both the tailnet AND the LAN (or even the public internet via a non-tailscale path), don't share its namespace with a kernel-mode Tailscale sidecar.**
 
+### Follow-up: the dind-daemon DNS gap
+
+A second, related gotcha lives one layer deeper: even with userspace mode + multi-network, **dind-spawned job containers don't see the parent Docker network's embedded DNS.** The embedded dind dockerd inside `gitea-runner` creates its own internal bridge network for job containers; that network has its own embedded resolver, which knows nothing about peer containers on the outer `gitea-net`. So even though `gitea-runner` itself can resolve `tailscale-runner` via gitea-net's DNS, job containers it spawns cannot. Workflows that try to hit the userspace proxy (`http://tailscale-runner:1099` / `socks5://tailscale-runner:1055`) fail at DNS resolution.
+
+**Quick fix (current implementation):** Capture the sidecar's `gitea-net` IP at deploy time (via `community.docker.docker_container_info`) and inject `--add-host=tailscale-runner:<IP>` into the act_runner's `container.options`, which is applied to every job container. Brittle if the sidecar restarts and Docker hands it a new IP from its DHCP pool — re-running the playbook re-captures and reconciles. Acceptable for the current single-runner scale.
+
+**Permanent fix (future):** Drop dind entirely and mount the host's `/var/run/docker.sock` into the runner. Job containers would then live on `gitea-net` directly and inherit its embedded DNS, eliminating the gap. The trade-off is isolation: socket-mount gives job containers the same Docker authority as the host. For homelab single-tenant CI that's acceptable; for multi-tenant or hostile-job scenarios it isn't. See the "Which to use, when" table for the broader socket-mount discussion.
+
 ## References
 
 - [Tailscale userspace networking docs](https://tailscale.com/kb/1112/userspace-networking)

--- a/docs/architecture/tailscale-sidecar-modes.md
+++ b/docs/architecture/tailscale-sidecar-modes.md
@@ -88,7 +88,7 @@ This is exactly the failure mode that motivated this doc. See "The bug" below.
 
 ## The bug this prevented
 
-**Symptom:** A CI workflow's job container tried to resolve `unifi.lan.jaxzin.com` (a LAN hostname). DNS lookup timed out at 3 seconds. Same container could reach `100.100.100.100` (Tailscale's MagicDNS) in milliseconds.
+**Symptom:** A CI workflow's job container tried to resolve `unifi<lan-domain-suffix>` (a LAN hostname). DNS lookup timed out at 3 seconds. Same container could reach `100.100.100.100` (Tailscale's MagicDNS) in milliseconds.
 
 **Tracing the network state from inside the failing container:**
 

--- a/docs/architecture/tailscale-sidecar-modes.md
+++ b/docs/architecture/tailscale-sidecar-modes.md
@@ -37,7 +37,7 @@ This doc captures the trade-off so future reviewers don't have to re-discover it
 **Trade-off:**
 - Consumer's outbound traffic is filtered through the sidecar's view: only what the sidecar can route is reachable.
 - LAN access depends on the Docker bridge attachment, NOT on `tailscale0`. The default route inside the namespace is the Docker bridge gateway, which routes via host → eth0 → LAN.
-- BUT: **dind-spawned child containers inherit the sidecar's namespace transitively, and dind's own auto-created bridges sit inside that namespace.** A child container's NAT chain becomes: `child → dind auto-bridge → dind gateway → sidecar namespace → bridge attachment → host → LAN`. Each hop is a NAT-translation opportunity, and the host-side iptables `FORWARD` chain has to permit the flow at every step. Synology DSM (and likely other restrictive setups) drops or fails to MASQUERADE traffic from nested-bridge subnets that aren't pre-registered with the host's firewall — and Tailscale's `tailscale0`-routed traffic bypasses that chain entirely. **Result: child containers can reach the tailnet but not the LAN.**
+- BUT: **dind-spawned child containers inherit the sidecar's namespace transitively, and dind's own auto-created bridges sit inside that namespace.** A child container's NAT chain becomes: `child → dind auto-bridge → dind gateway → sidecar namespace → bridge attachment → host → LAN`. Each hop is a NAT-translation opportunity, and the host-side iptables `FORWARD` chain has to permit the flow at every step. In our environment (Synology DSM), the LAN-bound flow drops somewhere in this multi-hop NAT chain while `tailscale0`-routed traffic — which bypasses the chain entirely — continues to work. The exact dropping link wasn't pinpointed; restrictive host firewall rules and missing MASQUERADE registrations for nested-bridge subnets are plausible culprits, but on stricter or differently-configured hosts the failure surface may differ. **Result: child containers can reach the tailnet but not the LAN.**
 
 This is exactly the failure mode that motivated this doc. See "The bug" below.
 
@@ -86,6 +86,27 @@ This is exactly the failure mode that motivated this doc. See "The bug" below.
 | Service that needs **only LAN/internet**, no tailnet | No sidecar | Sidecar adds latency for no benefit |
 | Service that needs **only tailnet**, no LAN | Either works; kernel mode is slightly faster | Kernel mode bypasses one userspace hop |
 
+### A fourth option: socket-mount instead of dind
+
+For Docker-in-Docker workloads specifically (e.g., a CI runner that spawns
+job containers), there's a fourth option worth naming: **drop dind entirely
+and bind-mount the host's `/var/run/docker.sock` into the runner**. Job
+containers then spawn directly on the host's Docker daemon — they sit on
+real Docker networks the host knows about (e.g., `gitea-net`), inherit
+embedded DNS, and avoid every problem above (the LAN-multi-hop-NAT
+problem, the dind-daemon DNS gap, the certs-volume mismatch).
+
+**Why we don't do this here:** Socket-mounting gives every job container
+root-equivalent authority over the host's Docker daemon — a job can
+spawn privileged containers, mount the host filesystem, or stop the
+runner itself. For **multi-tenant or hostile-job scenarios** this is
+unacceptable. For our **homelab single-tenant** setup where every
+workflow runs trusted IaC, the isolation trade-off is acceptable, and
+socket-mount is on the table as a future simplification.
+
+This is a deliberate trade-off, not a free improvement: name it
+explicitly when revisiting.
+
 ## The bug this prevented
 
 **Symptom:** A CI workflow's job container tried to resolve `unifi<lan-domain-suffix>` (a LAN hostname). DNS lookup timed out at 3 seconds. Same container could reach `100.100.100.100` (Tailscale's MagicDNS) in milliseconds.
@@ -119,6 +140,6 @@ A second, related gotcha lives one layer deeper: even with userspace mode + mult
 ## References
 
 - [Tailscale userspace networking docs](https://tailscale.com/kb/1112/userspace-networking)
-- Diagnostic PR that surfaced this: [PR #24](https://gitea.forest-draconis.ts.net/jaxzin/jaxzin-infra-bootstrap/pulls/24) (forest-draconis Gitea instance)
+- Diagnostic PR that surfaced this: PR #24 on the self-hosted Gitea instance (`https://gitea.<tailnet>/jaxzin/jaxzin-infra-bootstrap/pulls/24`)
 - The 4 hotfix PRs (`#20`–`#23`) that chased CI symptoms before this root cause was identified
 - Brian's `fix/gitea-runner-job-container-docker-access` (PR #79) and `fix/gitea-runner-cert-bind-mount` (PR #80) — runner config fixes that are independent of this sidecar topology fix

--- a/playbooks/gitea-deploy.yml
+++ b/playbooks/gitea-deploy.yml
@@ -31,6 +31,7 @@
         - gitea_db_password
         - tailscale_tailnet
         - lan_domain
+        - lan_domain_suffix
         - gitea_lan_host
 
     - name: Validate Tailscale auth key

--- a/playbooks/gitea-deploy.yml
+++ b/playbooks/gitea-deploy.yml
@@ -94,6 +94,17 @@
         tailscale_state_dir: "{{ tailscale_runner_state_dir }}"
         tailscale_serve_enabled: false
         tailscale_host_ports: []
+        # The runner sidecar runs in userspace networking mode so peer
+        # containers on gitea-net (gitea-runner + its dind-spawned job
+        # containers) can route outbound tailnet traffic through the
+        # sidecar's SOCKS5/HTTP proxy without sharing its network
+        # namespace. Sharing the namespace (the old `network_mode:
+        # container:tailscale-runner` pattern) prevented job containers
+        # from reaching the LAN, because the sidecar's namespace only had
+        # tailnet interfaces. The Gitea sidecar stays in kernel mode
+        # because Tailscale Serve (HTTPS termination) requires the kernel
+        # TUN device.
+        tailscale_userspace_networking: true
       when: not in_gitea
 
     # only install the Gitea runner if bootstrapping the server from GitHub

--- a/playbooks/gitea-deploy.yml
+++ b/playbooks/gitea-deploy.yml
@@ -107,6 +107,39 @@
         tailscale_userspace_networking: true
       when: not in_gitea
 
+    # Capture the runner sidecar's gitea-net IP so we can inject it as an
+    # /etc/hosts entry into every job container the embedded dind dockerd
+    # spawns inside gitea-runner. The dind dockerd creates its own internal
+    # bridge networks for job containers; those networks don't share
+    # gitea-net's embedded DNS, so "tailscale-runner" is unresolvable from
+    # inside a job container. Workflows that hit the userspace HTTP/SOCKS5
+    # proxy (http://tailscale-runner:1099, socks5://tailscale-runner:1055)
+    # would fail to even resolve the hostname.
+    #
+    # Quick fix: read the sidecar's bridge IP at deploy time and bake it into
+    # `container.options` (--add-host) in the runner config. Brittle if the
+    # sidecar restarts and Docker hands it a different IP from its DHCP pool;
+    # re-running this playbook re-captures the IP and reconciles. Acceptable
+    # for the current single-runner scale.
+    #
+    # Permanent fix (future): drop dind entirely and mount the host
+    # /var/run/docker.sock into the runner instead. Job containers would
+    # then live on gitea-net directly and inherit its embedded DNS. That
+    # breaks the runner's isolation guarantees, so it's a deliberate
+    # trade-off, not a free improvement. See
+    # docs/architecture/tailscale-sidecar-modes.md.
+    - name: Inspect Tailscale runner sidecar for gitea-net IP
+      community.docker.docker_container_info:
+        name: "{{ tailscale_runner_container_name }}"
+      register: tailscale_runner_container_info
+      when: not in_gitea
+
+    - name: Set tailscale-runner gitea-net IP fact
+      set_fact:
+        tailscale_runner_gitea_net_ip: >-
+          {{ tailscale_runner_container_info.container.NetworkSettings.Networks[gitea_network_name].IPAddress }}
+      when: not in_gitea
+
     # only install the Gitea runner if bootstrapping the server from GitHub
     - name: Include gitea_runner role
       include_role:

--- a/playbooks/roles/gitea_runner/defaults/main.yml
+++ b/playbooks/roles/gitea_runner/defaults/main.yml
@@ -7,3 +7,25 @@ gitea_runner_memory_swap: "1024m"
 
 gitea_runner_config_file_parent: "{{ gitea_runner_data_path }}/conf"
 gitea_runner_config_file: "{{ gitea_runner_config_file_parent }}/config.yml"
+
+# Proxy env shared between the runner container itself (tasks/main.yml `env:`)
+# and the runner config that propagates the same env to every job container
+# (templates/config.yaml.j2 `runner.envs:`). Single source of truth so the
+# two surfaces can't drift.
+#
+# - 1099: Tailscale userspace HTTP CONNECT proxy listen port
+#   (TS_OUTBOUND_HTTP_PROXY_LISTEN); used by HTTP/HTTPS clients that honor
+#   *_PROXY env vars.
+# - 1055: Tailscale userspace SOCKS5 proxy listen port (TS_SOCKS5_SERVER);
+#   used by clients that speak SOCKS5 (e.g. tools driven by ALL_PROXY).
+#
+# NO_PROXY lists actual container short-names on gitea-net (which embedded
+# Docker DNS resolves) plus the LAN domain suffix so LAN hostnames bypass
+# the tailnet proxy and egress directly via the host's LAN interface.
+# Network names like "gitea-net" are NOT valid here — NO_PROXY matches
+# hostnames/IPs, not Docker network identifiers.
+gitea_runner_proxy_env:
+  HTTPS_PROXY: "http://{{ tailscale_runner_container_name }}:1099"
+  HTTP_PROXY:  "http://{{ tailscale_runner_container_name }}:1099"
+  ALL_PROXY:   "socks5://{{ tailscale_runner_container_name }}:1055"
+  NO_PROXY:    "localhost,127.0.0.1,docker,host.docker.internal,{{ lan_domain_suffix }},tailscale-runner,gitea-db,gitea-runner"

--- a/playbooks/roles/gitea_runner/tasks/main.yml
+++ b/playbooks/roles/gitea_runner/tasks/main.yml
@@ -81,7 +81,15 @@
     image: "{{ gitea_runner_image }}"
     state: started
     restart_policy: always
-    network_mode: "container:{{ tailscale_runner_container_name }}"
+    # Was: network_mode: "container:{{ tailscale_runner_container_name }}"
+    # That share collapsed all egress through the sidecar's tailnet-only
+    # interfaces, breaking LAN access for dind-spawned job containers
+    # (they could reach 100.64.0.0/10 via tailscale0 but not 192.168.x.x).
+    # Now: runner sits on the same Docker bridge as the userspace-mode
+    # sidecar, has direct LAN access via the host, and reaches the tailnet
+    # by HTTPS_PROXY/SOCKS5 through the sidecar.
+    networks:
+      - name: "{{ gitea_network_name }}"
     privileged: true
     env:
       CONFIG_FILE: "/data/conf/config.yml"
@@ -89,6 +97,13 @@
       GITEA_RUNNER_REGISTRATION_TOKEN: "{{ gitea_runner_token }}"
       GITEA_RUNNER_NAME: "nas-runner"
       DOCKER_INSECURE_NO_IPTABLES_RAW: "1" # needed for Docker-in-Docker on the Synology DSM which does not include iptables_raw kernel module
+      # Outbound HTTPS to the Gitea tailnet URL routes through the sidecar's
+      # userspace HTTP CONNECT proxy. LAN destinations bypass the proxy via
+      # NO_PROXY so they egress directly through the host's LAN interface.
+      HTTPS_PROXY: "http://{{ tailscale_runner_container_name }}:1099"
+      HTTP_PROXY:  "http://{{ tailscale_runner_container_name }}:1099"
+      ALL_PROXY:   "socks5://{{ tailscale_runner_container_name }}:1055"
+      NO_PROXY: "localhost,127.0.0.1,docker,host.docker.internal,.lan.jaxzin.com,{{ gitea_network_name }}"
     volumes:
       - "{{ gitea_runner_data_path }}:/data"
       # dind's docker-init writes TLS server+client certs into /certs on first

--- a/playbooks/roles/gitea_runner/tasks/main.yml
+++ b/playbooks/roles/gitea_runner/tasks/main.yml
@@ -91,19 +91,24 @@
     networks:
       - name: "{{ gitea_network_name }}"
     privileged: true
-    env:
-      CONFIG_FILE: "/data/conf/config.yml"
-      GITEA_INSTANCE_URL: "{{ gitea_instance_url }}"
-      GITEA_RUNNER_REGISTRATION_TOKEN: "{{ gitea_runner_token }}"
-      GITEA_RUNNER_NAME: "nas-runner"
-      DOCKER_INSECURE_NO_IPTABLES_RAW: "1" # needed for Docker-in-Docker on the Synology DSM which does not include iptables_raw kernel module
-      # Outbound HTTPS to the Gitea tailnet URL routes through the sidecar's
-      # userspace HTTP CONNECT proxy. LAN destinations bypass the proxy via
-      # NO_PROXY so they egress directly through the host's LAN interface.
-      HTTPS_PROXY: "http://{{ tailscale_runner_container_name }}:1099"
-      HTTP_PROXY:  "http://{{ tailscale_runner_container_name }}:1099"
-      ALL_PROXY:   "socks5://{{ tailscale_runner_container_name }}:1055"
-      NO_PROXY: "localhost,127.0.0.1,docker,host.docker.internal,.lan.jaxzin.com,{{ gitea_network_name }}"
+    # Outbound HTTPS to the Gitea tailnet URL routes through the sidecar's
+    # userspace HTTP CONNECT proxy (HTTPS_PROXY/HTTP_PROXY) and SOCKS5
+    # (ALL_PROXY). LAN destinations bypass the proxy via NO_PROXY so they
+    # egress directly through the host's LAN interface. The shared
+    # gitea_runner_proxy_env dict (see defaults/main.yml) is also rendered
+    # into the runner config so dind-spawned job containers inherit the
+    # same proxy env.
+    #
+    # DOCKER_INSECURE_NO_IPTABLES_RAW=1 is required for the embedded
+    # Docker-in-Docker dockerd on Synology DSM, which does not include
+    # the iptables_raw kernel module.
+    env: "{{ gitea_runner_proxy_env | combine({
+      'CONFIG_FILE': '/data/conf/config.yml',
+      'GITEA_INSTANCE_URL': gitea_instance_url,
+      'GITEA_RUNNER_REGISTRATION_TOKEN': gitea_runner_token,
+      'GITEA_RUNNER_NAME': 'nas-runner',
+      'DOCKER_INSECURE_NO_IPTABLES_RAW': '1',
+    }) }}"
     volumes:
       - "{{ gitea_runner_data_path }}:/data"
       # dind's docker-init writes TLS server+client certs into /certs on first

--- a/playbooks/roles/gitea_runner/templates/config.yaml.j2
+++ b/playbooks/roles/gitea_runner/templates/config.yaml.j2
@@ -8,9 +8,17 @@ runner:
   # Execute how many tasks concurrently at the same time.
   capacity: 1
   # Extra environment variables to run jobs.
+  # HTTPS_PROXY/SOCKS5 route outbound tailnet traffic (e.g., the Gitea URL
+  # used by actions/checkout) through the Tailscale sidecar's userspace
+  # proxy. NO_PROXY exempts LAN + local destinations so they egress
+  # directly via the host. See gitea_runner role tasks/main.yml for the
+  # parallel env on the runner itself; this block propagates the same
+  # config to every job container spawned by the embedded dind dockerd.
   envs:
-    A_TEST_ENV_NAME_1: a_test_env_value_1
-    A_TEST_ENV_NAME_2: a_test_env_value_2
+    HTTPS_PROXY: "http://{{ tailscale_runner_container_name }}:1099"
+    HTTP_PROXY: "http://{{ tailscale_runner_container_name }}:1099"
+    ALL_PROXY: "socks5://{{ tailscale_runner_container_name }}:1055"
+    NO_PROXY: "localhost,127.0.0.1,docker,host.docker.internal,.lan.jaxzin.com,{{ gitea_network_name }}"
   # Extra environment variables to run jobs from a file.
   # It will be ignored if it's empty or the file doesn't exist.
   env_file: .env

--- a/playbooks/roles/gitea_runner/templates/config.yaml.j2
+++ b/playbooks/roles/gitea_runner/templates/config.yaml.j2
@@ -87,8 +87,17 @@ container:
   # - Map "docker" hostname to the host gateway, which (from inside a job
   #   container spawned by the dind dockerd) resolves to the dockerd itself.
   # - Inject DOCKER_HOST/TLS env vars so docker CLI in jobs connects with TLS.
+  # - Inject tailscale-runner:<gitea-net IP> via --add-host so job containers
+  #   can resolve the userspace proxy hostname. The embedded dind dockerd
+  #   spawns jobs on internal bridge networks that do NOT share gitea-net's
+  #   embedded DNS, so "tailscale-runner" is otherwise unresolvable from
+  #   inside a job container. The IP is captured at deploy time from the
+  #   sidecar's gitea-net attachment (see gitea-deploy.yml). Brittle if the
+  #   sidecar restarts and gets a new IP from Docker's DHCP pool; re-run the
+  #   playbook to reconcile. See docs/architecture/tailscale-sidecar-modes.md
+  #   for the quick-vs-permanent fix trade-off.
   # See fallen-leaf/ansible-runner-image#1.
-  options: "-v /certs/client:/certs/client:ro --add-host=docker:host-gateway -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client"
+  options: "-v /certs/client:/certs/client:ro --add-host=docker:host-gateway --add-host=tailscale-runner:{{ tailscale_runner_gitea_net_ip }} -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client"
   # The parent directory of a job's working directory.
   # NOTE: There is no need to add the first '/' of the path as act_runner will add it automatically.
   # If the path starts with '/', the '/' will be trimmed.

--- a/playbooks/roles/gitea_runner/templates/config.yaml.j2
+++ b/playbooks/roles/gitea_runner/templates/config.yaml.j2
@@ -11,14 +11,14 @@ runner:
   # HTTPS_PROXY/SOCKS5 route outbound tailnet traffic (e.g., the Gitea URL
   # used by actions/checkout) through the Tailscale sidecar's userspace
   # proxy. NO_PROXY exempts LAN + local destinations so they egress
-  # directly via the host. See gitea_runner role tasks/main.yml for the
-  # parallel env on the runner itself; this block propagates the same
-  # config to every job container spawned by the embedded dind dockerd.
+  # directly via the host. The values come from the shared
+  # gitea_runner_proxy_env dict (see defaults/main.yml) so this block
+  # cannot drift from the env: block on the runner container itself in
+  # tasks/main.yml.
   envs:
-    HTTPS_PROXY: "http://{{ tailscale_runner_container_name }}:1099"
-    HTTP_PROXY: "http://{{ tailscale_runner_container_name }}:1099"
-    ALL_PROXY: "socks5://{{ tailscale_runner_container_name }}:1055"
-    NO_PROXY: "localhost,127.0.0.1,docker,host.docker.internal,.lan.jaxzin.com,{{ gitea_network_name }}"
+{% for key, value in gitea_runner_proxy_env.items() %}
+    {{ key }}: "{{ value }}"
+{% endfor %}
   # Extra environment variables to run jobs from a file.
   # It will be ignored if it's empty or the file doesn't exist.
   env_file: .env

--- a/playbooks/roles/tailscale_sidecar/meta/main.yml
+++ b/playbooks/roles/tailscale_sidecar/meta/main.yml
@@ -63,6 +63,23 @@ argument_specs:
         required: false
         default: true
         description: "Accept DNS configuration from the tailnet (MagicDNS). Required for resolving tailnet hostnames."
+      tailscale_userspace_networking:
+        type: "bool"
+        required: false
+        default: false
+        description: >
+          Run Tailscale in userspace networking mode (TS_USERSPACE=true).
+          When true, the sidecar additionally exposes a SOCKS5 proxy on
+          :1055 (TS_SOCKS5_SERVER) and an HTTP CONNECT proxy on :1099
+          (TS_OUTBOUND_HTTP_PROXY_LISTEN) so peer containers on the same
+          Docker network can route outbound tailnet traffic through this
+          sidecar without sharing its network namespace. Userspace mode
+          does not require kernel TUN, so /dev/net/tun and the
+          NET_ADMIN/SYS_MODULE capabilities are skipped when this is
+          true. Trade-off: loses Tailscale Serve, exit-node, and
+          subnet-router features (those need kernel TUN). See
+          docs/architecture/tailscale-sidecar-modes.md for the full
+          discussion.
       tailscale_host_ports:
         type: "list"
         required: false

--- a/playbooks/roles/tailscale_sidecar/tasks/main.yml
+++ b/playbooks/roles/tailscale_sidecar/tasks/main.yml
@@ -48,6 +48,12 @@
       TS_ACCEPT_DNS: "{{ tailscale_accept_dns | default(true) | string | lower }}"
       TS_SERVE_CONFIG: "{{ '/etc/tailscale/serve.json' if (tailscale_serve_enabled | bool) else omit }}"
       TS_EXTRA_ARGS: "{{ tailscale_extra_args | default(omit, true) }}"
+      # In userspace networking mode, expose SOCKS5 (1055) and HTTP CONNECT
+      # (1099) proxies so peer containers on the same Docker network can
+      # route outbound tailnet traffic through this sidecar without sharing
+      # its network namespace. See https://tailscale.com/kb/1112/userspace-networking
+      TS_SOCKS5_SERVER: "{{ ':1055' if (tailscale_userspace_networking | default(false) | bool) else omit }}"
+      TS_OUTBOUND_HTTP_PROXY_LISTEN: "{{ ':1099' if (tailscale_userspace_networking | default(false) | bool) else omit }}"
     volumes: >-
       {{
         [tailscale_state_dir + ':/var/lib/tailscale',

--- a/playbooks/roles/tailscale_sidecar/tasks/main.yml
+++ b/playbooks/roles/tailscale_sidecar/tasks/main.yml
@@ -37,9 +37,14 @@
       - name: "{{ tailscale_network_name }}"
     ports: "{{ tailscale_host_ports | default([], true) }}"
     dns_servers: "{{ ['100.100.100.100'] if not (tailscale_accept_dns | default(true) | bool) else omit }}"
-    capabilities:
-      - NET_ADMIN
-      - SYS_MODULE
+    # Kernel-mode Tailscale needs CAP_NET_ADMIN + CAP_SYS_MODULE plus the
+    # /dev/net/tun device to bring up its kernel TUN interface. Userspace
+    # mode (TS_USERSPACE=true) routes WireGuard packets entirely in user
+    # space, so neither the capabilities nor the device node are needed.
+    # Granting them anyway over-grants privileges and contradicts the
+    # architecture rationale for choosing userspace mode in the first
+    # place. Conditional: kernel mode only.
+    capabilities: "{{ ['NET_ADMIN', 'SYS_MODULE'] if not (tailscale_userspace_networking | default(false) | bool) else omit }}"
     env:
       TS_HOSTNAME: "{{ tailscale_hostname }}"
       TS_AUTHKEY: "{{ tailscale_authkey }}"
@@ -54,10 +59,13 @@
       # its network namespace. See https://tailscale.com/kb/1112/userspace-networking
       TS_SOCKS5_SERVER: "{{ ':1055' if (tailscale_userspace_networking | default(false) | bool) else omit }}"
       TS_OUTBOUND_HTTP_PROXY_LISTEN: "{{ ':1099' if (tailscale_userspace_networking | default(false) | bool) else omit }}"
+    # /dev/net/tun is bind-mounted only in kernel mode (see capabilities
+    # comment above). Userspace mode never opens the device.
     volumes: >-
       {{
-        [tailscale_state_dir + ':/var/lib/tailscale',
-         '/dev/net/tun:/dev/net/tun']
+        [tailscale_state_dir + ':/var/lib/tailscale']
+        + (['/dev/net/tun:/dev/net/tun']
+           if not (tailscale_userspace_networking | default(false) | bool) else [])
         + ([tailscale_serve_config_dir + ':/etc/tailscale:ro']
            if (tailscale_serve_enabled | bool) else [])
       }}

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -4,6 +4,12 @@
 # =============================================================================
 tailscale_tailnet: "{{ lookup('ansible.builtin.env', 'TS_TAILNET') }}"
 lan_domain: "{{ lookup('ansible.builtin.env', 'NAS_HOST') }}"
+# LAN DNS suffix (e.g. ".lan.example.com") used for NO_PROXY exemption
+# inside the gitea-runner so LAN hostnames bypass the userspace tailnet
+# proxy. Treated as topology (a Secret on both GitHub and Gitea Actions);
+# never bake the literal value into committed config. Must include the
+# leading dot (NO_PROXY treats a leading dot as a domain-suffix match).
+lan_domain_suffix: "{{ lookup('ansible.builtin.env', 'LAN_DOMAIN_SUFFIX') | default('', true) }}"
 
 # =============================================================================
 # Tailscale sidecar configuration

--- a/tests/check_docker_tasks.py
+++ b/tests/check_docker_tasks.py
@@ -7,6 +7,8 @@ Checks:
   C) standalone container tasks should have networks defined (warning)
   D) Gitea Tailscale sidecar tailscale_host_ports must include loopback HTTP
      AND LAN SSH bindings
+  E) gitea-runner task must NOT use network_mode: container:* (regression
+     lock-in — see docs/architecture/tailscale-sidecar-modes.md)
 
 Uses only Python stdlib — no PyYAML required.
 """
@@ -62,8 +64,16 @@ def is_docker_container_task(block):
 
 
 def has_container_network_mode(block):
-    """Check if task block has network_mode: container:*"""
+    """Check if task block has network_mode: container:*
+
+    Skips YAML comment lines (those starting with '#' after lstrip) so that
+    historical-reference comments like `# Was: network_mode: "container:..."`
+    don't trip the check. Only the live parameter should match.
+    """
     for line in block:
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
         if re.search(r'network_mode:\s*["\']?container:', line):
             return True
     return False
@@ -170,6 +180,50 @@ def check_d_gitea_sidecar_host_ports():
     return failures
 
 
+RUNNER_FORBIDDEN_NETWORK_MODE_REASON = (
+    "The gitea-runner task must NOT use `network_mode: container:*`. Sharing the "
+    "Tailscale sidecar's namespace collapses egress to the sidecar's view; "
+    "dind-spawned job containers then can reach the tailnet but not the LAN "
+    "(see docs/architecture/tailscale-sidecar-modes.md). The runner sits on "
+    "gitea-net and reaches the tailnet via the sidecar's userspace HTTP/SOCKS5 "
+    "proxy instead."
+)
+
+
+def check_e_runner_no_container_network_mode(errors):
+    """Check E: gitea-runner role tasks must not use network_mode: container:*.
+
+    Regression lock-in: if anyone re-introduces the namespace-share, this fails
+    at static-check time before it ships.
+    """
+    filepath = f"{ROLES_DIR}/gitea_runner/tasks/main.yml"
+    try:
+        with open(filepath) as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        errors.append(f"{filepath}: File not found")
+        return
+
+    blocks = split_into_task_blocks(lines)
+    for block in blocks:
+        if not is_docker_container_task(block):
+            continue
+        # Only inspect tasks that target the gitea-runner container
+        if not any(re.search(r'name:\s*["\']?gitea-runner["\']?\s*$', ln) for ln in block):
+            continue
+        if has_container_network_mode(block):
+            task_name = ""
+            for line in block:
+                m = re.search(r'-\s*name:\s*(.+)', line)
+                if m:
+                    task_name = m.group(1).strip()
+                    break
+            errors.append(
+                f"{filepath}: Task '{task_name}' uses forbidden network_mode: "
+                f"container:* on gitea-runner. {RUNNER_FORBIDDEN_NETWORK_MODE_REASON}"
+            )
+
+
 def check_tailscale_sidecar(errors):
     """Check B: tailscale_sidecar must have TS_ACCEPT_DNS in env."""
     filepath = f"{ROLES_DIR}/tailscale_sidecar/tasks/main.yml"
@@ -216,6 +270,9 @@ def main():
 
     # Run check D on the Gitea deploy playbook
     errors.extend(check_d_gitea_sidecar_host_ports())
+
+    # Run check E: gitea-runner must not regress to network_mode: container:*
+    check_e_runner_no_container_network_mode(errors)
 
     # Report results
     for w in warnings:

--- a/tests/test-regression.yml
+++ b/tests/test-regression.yml
@@ -162,6 +162,126 @@
         fail_msg: "ts-serve config should reference the tailnet domain"
 
     # ================================================================
+    # Check 6: tailscale_sidecar role correctly gates userspace env vars
+    # ================================================================
+    # Static grep over tasks/main.yml — guarantees that the userspace-mode
+    # SOCKS5/HTTP proxy listeners are wired with the documented port
+    # numbers and gated on tailscale_userspace_networking. Catches a
+    # naive refactor that drops the gating or changes a port silently.
+    - name: "CHECK 6: Read tailscale_sidecar tasks/main.yml"
+      slurp:
+        src: "{{ roles_dir }}/tailscale_sidecar/tasks/main.yml"
+      register: tailscale_sidecar_tasks_raw
+
+    - name: "CHECK 6: Decode tailscale_sidecar tasks/main.yml"
+      set_fact:
+        tailscale_sidecar_tasks: "{{ tailscale_sidecar_tasks_raw.content | b64decode }}"
+
+    - name: "CHECK 6: Assert TS_SOCKS5_SERVER is wired to :1055 + userspace gate"
+      assert:
+        that:
+          - "'TS_SOCKS5_SERVER' in tailscale_sidecar_tasks"
+          - "':1055' in tailscale_sidecar_tasks"
+          - "'tailscale_userspace_networking' in tailscale_sidecar_tasks"
+        fail_msg: >
+          tailscale_sidecar/tasks/main.yml must wire TS_SOCKS5_SERVER to
+          ':1055' and gate it on tailscale_userspace_networking.
+
+    - name: "CHECK 6: Assert TS_OUTBOUND_HTTP_PROXY_LISTEN is wired to :1099"
+      assert:
+        that:
+          - "'TS_OUTBOUND_HTTP_PROXY_LISTEN' in tailscale_sidecar_tasks"
+          - "':1099' in tailscale_sidecar_tasks"
+        fail_msg: >
+          tailscale_sidecar/tasks/main.yml must wire
+          TS_OUTBOUND_HTTP_PROXY_LISTEN to ':1099'.
+
+    - name: "CHECK 6: Assert TS_USERSPACE env is wired to the variable"
+      assert:
+        that:
+          - "'TS_USERSPACE' in tailscale_sidecar_tasks"
+        fail_msg: >
+          tailscale_sidecar/tasks/main.yml must export TS_USERSPACE so
+          consumers can opt into userspace mode.
+
+    # ================================================================
+    # Check 7: gitea_runner config.yaml.j2 renders proxy env correctly
+    # ================================================================
+    # End-to-end render of the Jinja2 template with synthetic but
+    # realistic values, then asserts on the resulting YAML. Catches both
+    # template-rendering regressions and proxy-env content drift (e.g.
+    # someone removes ALL_PROXY, swaps the port, or breaks NO_PROXY).
+    - name: "CHECK 7: Render gitea_runner config.yaml.j2 with synthetic vars"
+      template:
+        src: "{{ roles_dir }}/gitea_runner/templates/config.yaml.j2"
+        dest: /tmp/test-gitea-runner-config.yml
+      vars:
+        # Match the production var names so the template compiles without
+        # touching the real defaults/main.yml. The values are synthetic.
+        tailscale_runner_container_name: "tailscale-runner"
+        tailscale_runner_gitea_net_ip: "172.20.0.42"
+        lan_domain_suffix: ".lan.test.example"
+        gitea_runner_proxy_env:
+          HTTPS_PROXY: "http://tailscale-runner:1099"
+          HTTP_PROXY: "http://tailscale-runner:1099"
+          ALL_PROXY: "socks5://tailscale-runner:1055"
+          NO_PROXY: "localhost,127.0.0.1,docker,host.docker.internal,.lan.test.example,tailscale-runner,gitea-db,gitea-runner"
+
+    - name: "CHECK 7: Read rendered gitea_runner config"
+      slurp:
+        src: /tmp/test-gitea-runner-config.yml
+      register: rendered_runner_config_raw
+
+    - name: "CHECK 7: Decode rendered gitea_runner config"
+      set_fact:
+        rendered_runner_config: "{{ rendered_runner_config_raw.content | b64decode }}"
+
+    - name: "CHECK 7: Assert HTTPS_PROXY uses the userspace HTTP CONNECT port"
+      assert:
+        that:
+          - "'HTTPS_PROXY: \"http://tailscale-runner:1099\"' in rendered_runner_config"
+        fail_msg: >
+          Rendered runner config must export
+          HTTPS_PROXY=http://tailscale-runner:1099. Got:
+          {{ rendered_runner_config }}
+
+    - name: "CHECK 7: Assert ALL_PROXY uses the userspace SOCKS5 port"
+      assert:
+        that:
+          - "'ALL_PROXY: \"socks5://tailscale-runner:1055\"' in rendered_runner_config"
+        fail_msg: >
+          Rendered runner config must export
+          ALL_PROXY=socks5://tailscale-runner:1055. Got:
+          {{ rendered_runner_config }}
+
+    - name: "CHECK 7: Assert NO_PROXY exempts the LAN suffix and gitea-net peers"
+      assert:
+        that:
+          # LAN suffix from the test fixture (proves the variable is wired
+          # through the proxy-env dict, not hardcoded in the template).
+          - "'.lan.test.example' in rendered_runner_config"
+          # Real container short names that Docker DNS resolves on
+          # gitea-net (NOT the network name itself, which is a no-op).
+          - "'tailscale-runner,gitea-db,gitea-runner' in rendered_runner_config"
+        fail_msg: >
+          Rendered runner config NO_PROXY must include the LAN suffix
+          and gitea-net container short names. Got:
+          {{ rendered_runner_config }}
+
+    - name: "CHECK 7: Assert add-host injection placeholder is documented"
+      assert:
+        that:
+          # The IP-injection lives in container.options (not envs), but
+          # the template should reference the variable so it renders
+          # under test. Asserts the var is consumed somewhere.
+          - "'172.20.0.42' in rendered_runner_config"
+        fail_msg: >
+          Rendered runner config must reference
+          tailscale_runner_gitea_net_ip (deploy-time IP injection for
+          dind-spawned job containers). Got:
+          {{ rendered_runner_config }}
+
+    # ================================================================
     # Cleanup
     # ================================================================
     - name: Clean up rendered test files
@@ -171,3 +291,4 @@
       loop:
         - /tmp/test-app-ini-rendered
         - /tmp/test-ts-serve-rendered.json
+        - /tmp/test-gitea-runner-config.yml


### PR DESCRIPTION
Stacked on top of #81. Addresses the root cause of the network.yml LAN-reachability failures: `gitea-runner` was sharing the `tailscale-runner` namespace, collapsing all egress through tailscale0 and breaking LAN access for dind-spawned job containers.

## Diagnosis

Diagnostic PR #24 (forest-draconis Gitea) printed network state from inside a failing job container and confirmed:

- LAN_DNS (192.168.10.1) on TCP/53 — **timeout (3s, no response)**
- MagicDNS (100.100.100.100) on TCP/53 — **immediate connect**
- `getent hosts unifi.lan.jaxzin.com` — hung 24s, returned `rc=2`
- `curl` to public B2 endpoint — also failed at DNS resolution

The asymmetry (tailnet works, LAN doesn't) pointed at the sidecar's namespace-collapse pattern: `100.x` traffic hit Tailscale's installed routes via `tailscale0`, but `192.168.x.x` traffic had to NAT through a multi-hop chain (dind auto-bridge → sidecar namespace → gitea-net bridge → host eth0) that the host's iptables `FORWARD`/`POSTROUTING` chains didn't carry through — likely the Synology DSM firewall, but the structural fragility is general.

## Fix

**Asymmetric sidecar mode:**

- Gitea sidecar stays **kernel-mode** (`network_mode: container:tailscale-gitea`) because Tailscale Serve terminates HTTPS for the tailnet on the kernel TUN device.
- Runner sidecar switches to **userspace networking mode** (`TS_USERSPACE=true`) and exposes SOCKS5 / HTTP-CONNECT proxies on `:1055` / `:1099` for peer containers.
- `gitea-runner` joins `gitea-net` directly (no more `network_mode: container:...`), giving dind-spawned job containers a normal Docker → host → eth0 → LAN egress path.
- The runner reaches the tailnet via `HTTPS_PROXY=http://tailscale-runner:1099`; same env propagates to job containers via `runner.envs` in the act_runner config so `actions/checkout` against the tailnet Gitea URL keeps working.

## Files

- `playbooks/roles/tailscale_sidecar/tasks/main.yml` — conditional `TS_SOCKS5_SERVER` + `TS_OUTBOUND_HTTP_PROXY_LISTEN` env vars when userspace mode.
- `playbooks/gitea-deploy.yml` — runner sidecar invocation gets `tailscale_userspace_networking: true`.
- `playbooks/roles/gitea_runner/tasks/main.yml` — `network_mode` → `networks` + proxy env vars.
- `playbooks/roles/gitea_runner/templates/config.yaml.j2` — proxy env vars propagated to job containers.
- `README.md` — Tailscale Integration section explains the asymmetric mode choice.
- `docs/architecture/tailscale-sidecar-modes.md` — new architecture note. Generalizable lesson for future sidecar deployments + failure pattern documented.

## Verified

- `ansible-playbook tests/test-regression.yml` — 20/0 clean.
- Stacked cleanly on #81.

## What this does NOT do

- Doesn't deploy. Brian still needs to run the bootstrap workflow against the NAS to apply the new gitea_runner config.
- Doesn't fix Synology's firewall. The new topology routes around it.
- Doesn't change Gitea itself. Only the runner sidecar moves to userspace mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)