### PR TITLE
fix(ci): pass LAN_DNS as workflow_call input (unblocks bootstrap dispatch)

### DIFF
--- a/.gitea/workflows/deploy.yml
+++ b/.gitea/workflows/deploy.yml
@@ -9,4 +9,8 @@ jobs:
     uses: ./.github/workflows/common-bootstrap.yml
     with:
       dry_run: false
+      # common-bootstrap.yml's container.options cannot reference secrets
+      # directly (evaluated at workflow-load time, before secrets context
+      # is in scope); pass the value as an explicit input instead.
+      lan_dns: ${{ secrets.LAN_DNS }}
     secrets: inherit

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -9,4 +9,8 @@ jobs:
     uses: ./.github/workflows/common-bootstrap.yml
     with:
       dry_run: false
+      # common-bootstrap.yml's container.options cannot reference secrets
+      # directly (evaluated at workflow-load time, before secrets context
+      # is in scope); pass the value as an explicit input instead.
+      lan_dns: ${{ secrets.LAN_DNS }}
     secrets: inherit

--- a/.github/workflows/common-bootstrap.yml
+++ b/.github/workflows/common-bootstrap.yml
@@ -6,13 +6,23 @@ on:
         description: "If true, run Ansible in --check mode"
         required: true
         type: boolean
+      lan_dns:
+        # GitHub Actions evaluates `container.options` at workflow-load time,
+        # before the `secrets` context is available. `secrets.X` is therefore
+        # rejected in container.options with "Unrecognized named-value:
+        # 'secrets'". Callers pass the LAN DNS value as an explicit input
+        # (sourcing from `secrets.LAN_DNS` on their side), and we read it
+        # here from `inputs.lan_dns` where the expression IS evaluable.
+        description: "LAN DNS server IP for the container's --dns option"
+        required: true
+        type: string
 
 jobs:
   bootstrap:
     runs-on: [self-hosted, linux]
     container:
       image: ghcr.io/jaxzin/jaxzin-infra-runner:latest
-      options: --dns ${{ secrets.LAN_DNS }}
+      options: --dns ${{ inputs.lan_dns }}
     env:
       CERTBOT_EMAIL: ${{ vars.CERTBOT_EMAIL }}
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -10,6 +10,10 @@ jobs:
     uses: ./.github/workflows/common-bootstrap.yml
     with:
       dry_run: true
+      # common-bootstrap.yml's container.options cannot reference secrets
+      # directly (evaluated at workflow-load time, before secrets context
+      # is in scope); pass the value as an explicit input instead.
+      lan_dns: ${{ secrets.LAN_DNS }}
     secrets: inherit
 
   notify-on-failure:


### PR DESCRIPTION
## Why

\`gh workflow run bootstrap.yml\` returns HTTP 422:

\`\`\`
failed to parse workflow: error parsing called workflow
(\`./.github/workflows/common-bootstrap.yml\`)
(Line: 15, Col: 16): Unrecognized named-value: 'secrets'.
Located at position 1 within expression: secrets.LAN_DNS
\`\`\`

GitHub Actions evaluates \`container.options\` at workflow-load time, before the \`secrets\` context is in scope. PR #16's migration moved \`vars.LAN_DNS\` to \`secrets.LAN_DNS\` on that one specific line, which broke validation. The 0s "failure" runs visible on \`gh run list\` for the workflow files themselves were the canary.

## What

Declare \`lan_dns\` as a \`workflow_call\` input in \`common-bootstrap.yml\`; reference \`\${{ inputs.lan_dns }}\` in container.options. Each caller passes \`lan_dns: \${{ secrets.LAN_DNS }}\`. LAN_DNS stays a Secret end-to-end; only the plumbing layer changes.

## Files

- \`.github/workflows/common-bootstrap.yml\` — declare input + use in container.options
- \`.github/workflows/bootstrap.yml\` — pass \`lan_dns\`
- \`.github/workflows/health-check.yml\` — pass \`lan_dns\` (health-check job)
- \`.gitea/workflows/deploy.yml\` — pass \`lan_dns\`

## Out of scope

- \`.github/workflows/network.yml\` and the \`tofu-network-drift\` job in \`health-check.yml\` have the same \`secrets.X\`-in-container.options issue but aren't \`workflow_call\` workflows; they need a different fix (setup-step DNS or wrapper-workflow refactor). Tracked as follow-up.

## Verification

- All 4 modified YAMLs parse cleanly.
- After merge: \`gh workflow run bootstrap.yml\` should accept and dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)