### PR TITLE
fix(ci): override /etc/resolv.conf at job start (replaces PR #85)

### DIFF
--- a/.gitea/workflows/deploy.yml
+++ b/.gitea/workflows/deploy.yml
@@ -9,8 +9,4 @@ jobs:
     uses: ./.github/workflows/common-bootstrap.yml
     with:
       dry_run: false
-      # common-bootstrap.yml's container.options cannot reference secrets
-      # directly (evaluated at workflow-load time, before secrets context
-      # is in scope); pass the value as an explicit input instead.
-      lan_dns: ${{ secrets.LAN_DNS }}
     secrets: inherit

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -9,8 +9,4 @@ jobs:
     uses: ./.github/workflows/common-bootstrap.yml
     with:
       dry_run: false
-      # common-bootstrap.yml's container.options cannot reference secrets
-      # directly (evaluated at workflow-load time, before secrets context
-      # is in scope); pass the value as an explicit input instead.
-      lan_dns: ${{ secrets.LAN_DNS }}
     secrets: inherit

--- a/.github/workflows/common-bootstrap.yml
+++ b/.github/workflows/common-bootstrap.yml
@@ -6,23 +6,23 @@ on:
         description: "If true, run Ansible in --check mode"
         required: true
         type: boolean
-      lan_dns:
-        # GitHub Actions evaluates `container.options` at workflow-load time,
-        # before the `secrets` context is available. `secrets.X` is therefore
-        # rejected in container.options with "Unrecognized named-value:
-        # 'secrets'". Callers pass the LAN DNS value as an explicit input
-        # (sourcing from `secrets.LAN_DNS` on their side), and we read it
-        # here from `inputs.lan_dns` where the expression IS evaluable.
-        description: "LAN DNS server IP for the container's --dns option"
-        required: true
-        type: string
 
 jobs:
   bootstrap:
     runs-on: [self-hosted, linux]
     container:
       image: ghcr.io/jaxzin/jaxzin-infra-runner:latest
-      options: --dns ${{ inputs.lan_dns }}
+      # NOTE: do NOT add `options: --dns ${{ secrets.LAN_DNS }}` here.
+      # GitHub Actions evaluates `container.options` at workflow-load time,
+      # before any of `secrets`, `inputs.<workflow_call-input>`-passed-from-
+      # secrets, or other secret-derived contexts are available. Both of
+      # those were tried (PR #16's direct `secrets.LAN_DNS`; PR #85's
+      # `inputs.lan_dns` via `with:` passed from caller `secrets.LAN_DNS`)
+      # and BOTH failed schema validation with:
+      #   "Unrecognized named-value: 'secrets'"
+      # The runtime DNS-override step below (first step of this job) does
+      # the same job from inside the running container, where `secrets`
+      # context IS available.
     env:
       CERTBOT_EMAIL: ${{ vars.CERTBOT_EMAIL }}
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
@@ -45,6 +45,24 @@ jobs:
       TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
       TS_TAILNET: ${{ secrets.TS_TAILNET }}
     steps:
+      # Must run BEFORE actions/checkout, which is the first network-using
+      # step. /etc/resolv.conf inside a Docker user-defined network is
+      # writable (it's an in-memory copy, not a host bind-mount), so
+      # overwriting it from a step works. Subsequent processes look up
+      # nameserver(s) here for every resolution. Includes MagicDNS as a
+      # fallback so tailnet hostnames (e.g. the Gitea origin URL used by
+      # checkout when triggered from the Gitea-side deploy.yml caller)
+      # also resolve. See docs/architecture/tailscale-sidecar-modes.md
+      # for the broader LAN-vs-tailnet DNS asymmetry context.
+      - name: Configure LAN DNS resolution inside container
+        env:
+          LAN_DNS: ${{ secrets.LAN_DNS }}
+        run: |
+          set -euo pipefail
+          printf 'nameserver %s\nnameserver %s\n' "$LAN_DNS" 100.100.100.100 > /etc/resolv.conf
+          echo "Configured /etc/resolv.conf:"
+          cat /etc/resolv.conf
+
       - name: Checkout IaC
         uses: actions/checkout@v4
 

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -10,10 +10,6 @@ jobs:
     uses: ./.github/workflows/common-bootstrap.yml
     with:
       dry_run: true
-      # common-bootstrap.yml's container.options cannot reference secrets
-      # directly (evaluated at workflow-load time, before secrets context
-      # is in scope); pass the value as an explicit input instead.
-      lan_dns: ${{ secrets.LAN_DNS }}
     secrets: inherit
 
   notify-on-failure:


### PR DESCRIPTION
## Why PR #85 didn't work

PR #85 declared \`lan_dns\` as a workflow_call input and had callers pass \`lan_dns: \${{ secrets.LAN_DNS }}\`. GitHub Actions rejected this on dispatch with the SAME schema error, just on a different line — turns out \`secrets.X\` is explicitly disallowed in \`with:\` blocks of reusable-workflow calls (per the official "Supported keywords for jobs that call a reusable workflow" docs).

Net constraint: **there is no path that keeps LAN_DNS as a Secret AND uses it in \`container.options\`.** Both attempted alternatives failed.

## This PR

Moves the DNS override OUT of \`container.options\` entirely. The first step of common-bootstrap.yml's bootstrap job writes \`/etc/resolv.conf\` inside the running container, using \`secrets.LAN_DNS\` via the \`env:\` context (which IS allowed). MagicDNS (100.100.100.100) added as a fallback nameserver so tailnet hostnames also resolve (e.g., the Gitea origin URL hit by \`actions/checkout\` when this is called from \`.gitea/workflows/deploy.yml\`).

LAN_DNS stays a Secret end-to-end. No security-status changes.

## Files

- \`.github/workflows/common-bootstrap.yml\` — drop \`options: --dns\` line + drop \`lan_dns\` input. Add new first step that writes \`/etc/resolv.conf\`. Detailed inline comment explains the constraint chain and what's been tried.
- \`.github/workflows/bootstrap.yml\` — drop \`lan_dns:\` from \`with:\`.
- \`.github/workflows/health-check.yml\` — same for the \`health-check\` job.
- \`.gitea/workflows/deploy.yml\` — same.

## Out of scope

\`.github/workflows/network.yml\` and the \`tofu-network-drift\` job in \`health-check.yml\` have the same \`secrets.X\`-in-container.options issue. Same runtime-step fix could apply, but those aren't blocking the bootstrap deploy. Tracked as follow-up.

## Verification

- YAML parses on all 4 modified files.
- After merge: \`gh workflow run bootstrap.yml\` should accept and dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)