### PR TITLE
fix(ci): drop pipefail in DNS-override step (dash, not bash)

### DIFF
--- a/.github/workflows/common-bootstrap.yml
+++ b/.github/workflows/common-bootstrap.yml
@@ -57,8 +57,11 @@ jobs:
       - name: Configure LAN DNS resolution inside container
         env:
           LAN_DNS: ${{ secrets.LAN_DNS }}
+        # The runner container's default shell is `sh`/`dash`, not bash —
+        # `set -o pipefail` is bash-only and would fail "Illegal option".
+        # The script has no pipes, so `set -eu` (POSIX) is sufficient.
         run: |
-          set -euo pipefail
+          set -eu
           printf 'nameserver %s\nnameserver %s\n' "$LAN_DNS" 100.100.100.100 > /etc/resolv.conf
           echo "Configured /etc/resolv.conf:"
           cat /etc/resolv.conf


### PR DESCRIPTION
PR #86's DNS-override step dispatched but failed at runtime:

\`\`\`
/__w/_temp/<uuid>.sh: 1: set: Illegal option -o pipefail
##[error]Process completed with exit code 2.
\`\`\`

The runner container's default shell is \`sh\`/\`dash\` (not bash). \`set -o pipefail\` is bash-only. The script has no pipes anyway, so dropping pipefail is functionally a no-op. \`set -eu\` (POSIX) stays.

Inline comment added to document the gotcha for future readers.

Trivial one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)