### PR TITLE
fix(deploy): raise docker-py client timeout to 180s for slow container replace on Synology

### DIFF
--- a/playbooks/gitea-deploy.yml
+++ b/playbooks/gitea-deploy.yml
@@ -5,6 +5,18 @@
   vars_files:
     - vars/main.yml
 
+  # docker-py's default 60s API client timeout is too tight for this host's
+  # container-replace operations. The slow path is removing a container that
+  # holds `network_mode: container:<X>` against an X we just replaced: Docker
+  # serializes netns detach + bridge endpoint removal + volume releases, and
+  # on Synology's older Docker 24.x that chain regularly exceeds 60s. When
+  # it does, Ansible fails with: "Error removing container ...:
+  # UnixHTTPConnectionPool... Read timed out. (read timeout=60)". 180s gives
+  # roomy headroom without making genuinely hung calls wait indefinitely.
+  module_defaults:
+    community.docker.docker_container:
+      timeout: 180
+
   roles:
     - role: tafeen.synology.syno_pkg_install
       syno_pkg_name: "Container Manager"


### PR DESCRIPTION
## Summary

- Raise the docker-py API client timeout from 60s (default) to 180s for all `community.docker.docker_container` calls in `gitea-deploy.yml`, via play-level `module_defaults`.
- Targets the slow-path failure mode hit during a real deploy (run 25773148916): removing a container with `network_mode: container:<X>` where X was just replaced. Docker serializes netns detach + bridge endpoint removal + volume releases, and on Synology's Docker 24.x that chain regularly exceeds 60s.

## Why this is needed

During the bootstrap deploy after PR #87 landed, the `Deploy Gitea container (with Tailscale sidecar)` task failed with:

```
Error removing container ...: UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)
```

Root cause: the old `gitea` container had `network_mode: container:tailscale-gitea` pointing at a tailscale-gitea that Ansible had just recreated. Removing the orphaned `gitea` then serialized through a chain of teardown ops in the daemon that, on this NAS, takes longer than 60s. Manual `docker rm gitea` outside the 60s budget unblocked the retry — but the root fix is to give Ansible more headroom.

180s gives 3× headroom over the observed slow case while still bounding a genuinely hung call.

## Scope

Applied at the play level via `module_defaults` rather than per-task, because the same risk applies to every `docker_container` call here (gitea-db, both Tailscale sidecars, gitea, gitea-runner) — any of them could be the recreate-replace victim on a future run.

`module_defaults` propagates into roles imported by the play, so the gitea_server and gitea_runner role tasks inherit the new timeout without per-call edits.

## Test plan

- [ ] Bootstrap deploy runs end-to-end without docker-py timeouts even when stale containers are present
- [ ] `ansible-playbook --check` still validates without warnings
- [ ] Run a deliberate stale-container scenario (leave a previous gitea Exited) and confirm Ansible recreates without 60s timeout

## Out of scope

- Other Ansible playbooks (`gitea-restore.yml`, etc.) — if/when they hit the same wall, apply the same pattern there.
- The orthogonal stale-container hygiene question (whether Ansible should pre-cleanup containers in `Created`/`Exited` state more aggressively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)