### PR TITLE
fix(gitea): map LAN-SSH host port to Gitea's actual listener (2222), not :22 (fixes #92)

### DIFF
--- a/playbooks/gitea-deploy.yml
+++ b/playbooks/gitea-deploy.yml
@@ -76,7 +76,15 @@
         tailscale_serve_ssh_forward_port: "{{ gitea_ssh_listen_port }}"
         tailscale_host_ports:
           - "127.0.0.1:{{ gitea_port }}:3000"
-          - "{{ gitea_lan_host }}:{{ gitea_lan_ssh_port }}:22"
+          # Container-side port is Gitea's actual SSH listener
+          # (gitea_ssh_listen_port = 2222), NOT :22. Inside the shared netns,
+          # :22 is bound by Tailscale Serve on the tailnet IP only (for the
+          # tailnet-side ssh://git@gitea.<tailnet>:22/... flow). LAN traffic
+          # arriving on :22 finds no matching listener and gets RST. Gitea
+          # itself listens on :::2222 (app.ini SSH_LISTEN_PORT). Same variable
+          # as line 76's tailscale_serve_ssh_forward_port keeps both paths
+          # consistent.
+          - "{{ gitea_lan_host }}:{{ gitea_lan_ssh_port }}:{{ gitea_ssh_listen_port }}"
 
     - name: Include gitea_server role
       include_role:

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -59,7 +59,9 @@ gitea_ssh_listen_port: "2222"
 gitea_ssh_domain: "gitea.{{ tailscale_tailnet }}"
 # LAN-side SSH binding: makes Gitea SSH reachable from non-tailnet LAN clients
 # (e.g., Home Assistant addon containers). Bound on the host's LAN interface
-# at gitea_lan_host:gitea_lan_ssh_port → container's internal :22.
+# at gitea_lan_host:gitea_lan_ssh_port → container's internal :{{ gitea_ssh_listen_port }}
+# (Gitea's actual SSH listener — :22 in the shared netns is reserved for
+# Tailscale Serve's tailnet-side ingress).
 # Both values must come from CI Secrets (not Variables) because they're topology.
 # Note: gitea_lan_host is shared with Plan #2 (UniFi static DNS) — the LAN-side
 # address of Gitea is a single concept; consumers (this binding, the DNS A

--- a/tests/check_docker_tasks.py
+++ b/tests/check_docker_tasks.py
@@ -21,7 +21,11 @@ FORBIDDEN_WITH_CONTAINER_MODE = ["dns_opts", "dns:", "dns_search", "networks", "
 
 GITEA_HOST_PORTS_REQUIRED = [
     re.compile(r'^["\']?127\.0\.0\.1:.*:3000["\']?$'),
-    re.compile(r'^["\']?\{\{\s*gitea_lan_host\s*\}\}:\{\{\s*gitea_lan_ssh_port\s*\}\}:22["\']?$'),
+    # Container-side port must be gitea_ssh_listen_port (= 2222 by default),
+    # NOT :22. Inside the shared netns, :22 is bound by Tailscale Serve on
+    # the tailnet IP only — LAN traffic to :22 gets RST. Gitea's actual
+    # listener is :::2222. See PR #93 / issue #92 for the full diagnosis.
+    re.compile(r'^["\']?\{\{\s*gitea_lan_host\s*\}\}:\{\{\s*gitea_lan_ssh_port\s*\}\}:\{\{\s*gitea_ssh_listen_port\s*\}\}["\']?$'),
 ]
 
 


### PR DESCRIPTION
## Summary

- Map the LAN-SSH host port to container port **2222** (Gitea's actual SSH listener), not **:22** (Tailscale Serve's tailnet-only port).
- Update the misleading "→ container's internal :22" comment in `vars/main.yml`.

Fixes #92.

## Root cause (full diagnosis in #92)

Inside the `tailscale-gitea` + `gitea` shared netns, `:22` is bound by **Tailscale Serve on the tailnet IP only** (it forwards tailnet ingress to `127.0.0.1:2222` per `ts-serve-gitea.json`'s `"22": TCPForward`). Gitea itself binds `:::2222` per `SSH_LISTEN_PORT` in `app.ini`.

The previous Docker host-port binding was `host:2222 → container:22`. LAN traffic arrived on container `:22` with a source IP that didn't match Tailscale Serve's tailnet-only listener, so the kernel sent RST. Smoke test result:

```
$ ssh -p 2222 -T git@<LAN_IP>
kex_exchange_identification: read: Connection reset by peer
```

## Fix

`playbooks/gitea-deploy.yml` line 79:

```diff
-  - "{{ gitea_lan_host }}:{{ gitea_lan_ssh_port }}:22"
+  - "{{ gitea_lan_host }}:{{ gitea_lan_ssh_port }}:{{ gitea_ssh_listen_port }}"
```

`gitea_ssh_listen_port` is the same variable line 76 (`tailscale_serve_ssh_forward_port`) already uses for the tailnet-ingress forward target — both paths now agree.

## Test plan

- [ ] After deploy: `ssh -p 2222 -T git@gitea.<lan-suffix>` returns Gitea's SSH banner (or `Permission denied (publickey)` — either proves SSH-protocol contact).
- [ ] Tailnet path `ssh -T git@gitea.<tailnet>` still works (unchanged config, just a sanity regression check).
- [ ] `git clone ssh://git@gitea.<lan-suffix>:2222/jaxzin/<repo>.git` succeeds end-to-end.

## Stacking note

This is orthogonal to PR #91 (docker-py client timeout). Either order of merge is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)