### PR TITLE
fix(gitea-runner): docker-init PID 1 + pin dind storage driver (the real #25 / ansible-runner-image#15 fix)

### DIFF
--- a/playbooks/roles/gitea_runner/defaults/main.yml
+++ b/playbooks/roles/gitea_runner/defaults/main.yml
@@ -8,6 +8,17 @@ gitea_runner_memory_swap: "1024m"
 gitea_runner_config_file_parent: "{{ gitea_runner_data_path }}/conf"
 gitea_runner_config_file: "{{ gitea_runner_config_file_parent }}/config.yml"
 
+# Inner dind dockerd storage driver. Pinned (not auto-detected) because on
+# the Synology DSM kernel dockerd's auto-probe fails overlay2 ("no such
+# device") then fuse-overlayfs ("not found") before falling back to btrfs;
+# every dockerd (re)start re-runs that fragile probe and a job container
+# landing mid-probe crashloops (Gitea fallen-leaf/ansible-runner-image#15).
+# btrfs is what the probe empirically settles on and what the Synology
+# volume backing the runner's /var/lib/docker supports — pin it so dockerd
+# goes straight there instead of cycling through the broken drivers.
+gitea_runner_storage_driver: "btrfs"
+gitea_runner_dind_daemon_json: "{{ gitea_runner_config_file_parent }}/daemon.json"
+
 # Proxy env shared between the runner container itself (tasks/main.yml `env:`)
 # and the runner config that propagates the same env to every job container
 # (templates/config.yaml.j2 `runner.envs:`). Single source of truth so the

--- a/playbooks/roles/gitea_runner/tasks/main.yml
+++ b/playbooks/roles/gitea_runner/tasks/main.yml
@@ -60,6 +60,24 @@
   notify:
     - Restart Gitea runner
 
+# Pin the inner dind dockerd's storage driver. Bind-mounted to the dockerd
+# default config path (the runner's dockerd runs with no --config-file, so
+# /etc/docker/daemon.json is what it reads). Without this, dockerd
+# auto-probes overlay2 -> fuse-overlayfs (both fail on the DSM kernel) ->
+# btrfs on every (re)start; a job landing mid-probe crashloops, which
+# starves the act_runner heartbeat and flaps the runner offline. See
+# gitea_runner_storage_driver in defaults/main.yml and
+# Gitea fallen-leaf/ansible-runner-image#15.
+- name: Ensure dind daemon.json pins a working storage driver
+  copy:
+    dest: "{{ gitea_runner_dind_daemon_json }}"
+    content: "{{ {'storage-driver': gitea_runner_storage_driver} | to_nice_json }}\n"
+    owner: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    group: "users"
+    mode: '0644'
+  notify:
+    - Restart Gitea runner
+
 # --- Runner container deployment (conditional on Tailscale) ---
 
 # Healthcheck used by both deploy variants below. Detects the s6 init wedge
@@ -81,6 +99,14 @@
     image: "{{ gitea_runner_image }}"
     state: started
     restart_policy: always
+    # Run docker-init (tini) as PID 1 of this container so it subreaps
+    # zombies from dind-spawned job containers. Without --init, PID 1 is
+    # s6-svscan (verified on the live runner) which is not a subreaper;
+    # crashlooping job containers then leak zombies + libnetwork/conntrack
+    # state and starve the act_runner heartbeat (Gitea
+    # fallen-leaf/ansible-runner-image#15; same fix class as obsidian-mcp's
+    # vault-sync init:true).
+    init: true
     # Was: network_mode: "container:{{ tailscale_runner_container_name }}"
     # That share collapsed all egress through the sidecar's tailnet-only
     # interfaces, breaking LAN access for dind-spawned job containers
@@ -111,6 +137,8 @@
     }) }}"
     volumes:
       - "{{ gitea_runner_data_path }}:/data"
+      # Pin the inner dind dockerd storage driver (see daemon.json task above).
+      - "{{ gitea_runner_dind_daemon_json }}:/etc/docker/daemon.json:ro"
       # dind's docker-init writes TLS server+client certs into /certs on first
       # start. Sharing this as a named volume lets job containers mount
       # /certs/client read-only so their docker CLI can speak TLS to the dind
@@ -130,6 +158,9 @@
     image: "{{ gitea_runner_image }}"
     state: started
     restart_policy: always
+    # See the with-Tailscale variant above: docker-init as PID 1 subreaps
+    # dind job-container zombies (Gitea fallen-leaf/ansible-runner-image#15).
+    init: true
     memory: "{{ gitea_runner_memory_limit }}"
     memory_swap: "{{ gitea_runner_memory_swap }}"
     networks:
@@ -145,6 +176,8 @@
       DOCKER_INSECURE_NO_IPTABLES_RAW: "1" # needed for Docker-in-Docker on the Synology DSM which does not include iptables_raw kernel module
     volumes:
       - "{{ gitea_runner_data_path }}:/data"
+      # Pin the inner dind dockerd storage driver (see daemon.json task above).
+      - "{{ gitea_runner_dind_daemon_json }}:/etc/docker/daemon.json:ro"
       # dind's docker-init writes TLS server+client certs into /certs on first
       # start. Sharing this as a named volume lets job containers mount
       # /certs/client read-only so their docker CLI can speak TLS to the dind

--- a/tests/check_docker_tasks.py
+++ b/tests/check_docker_tasks.py
@@ -14,6 +14,10 @@ Checks:
   G) tailscale_sidecar role must fail fast with an auth-aware message on an
      expired/revoked TS_AUTHKEY and assert a usable tailnet route, not just
      BackendState==Running (regression lock-in — see Gitea issue #25)
+  H) gitea_runner role must run docker-init as PID 1 (init: true on both
+     deploy variants) and pin the inner dind storage driver via a
+     /etc/docker/daemon.json bind-mount (regression lock-in — see Gitea
+     fallen-leaf/ansible-runner-image#15)
 
 Uses only Python stdlib — no PyYAML required.
 """
@@ -41,6 +45,14 @@ AUTHKEY_FAILFAST_MARKERS = (
     "Self.Online",
     "docs/runbooks/tailscale-authkey-rotation.md",
 )
+
+GITEA_RUNNER_TASKS = f"{ROLES_DIR}/gitea_runner/tasks/main.yml"
+# Both gitea-runner deploy variants (with-Tailscale + standalone) must run
+# docker-init as PID 1 (init: true) AND pin the inner dind storage driver
+# via a bind-mounted /etc/docker/daemon.json. See Gitea
+# fallen-leaf/ansible-runner-image#15.
+GITEA_RUNNER_INIT_MIN = 2
+GITEA_RUNNER_DAEMON_JSON_MARKER = "/etc/docker/daemon.json"
 
 GITEA_HOST_PORTS_REQUIRED = [
     re.compile(r'^["\']?127\.0\.0\.1:.*:3000["\']?$'),
@@ -347,6 +359,46 @@ def check_g_tailscale_authkey_failfast(errors):
         )
 
 
+def check_h_gitea_runner_dind_hardening(errors):
+    """Check H: the gitea_runner role must run docker-init as PID 1
+    (init: true on BOTH deploy variants) AND pin the inner dind storage
+    driver via a bind-mounted /etc/docker/daemon.json.
+
+    Without init:true, PID 1 is s6-svscan (not a subreaper, verified on
+    the live runner) so crashlooping dind job-container zombies starve
+    the act_runner heartbeat. Without the pinned storage driver, dockerd
+    auto-probes overlay2 -> fuse-overlayfs (both fail on the DSM kernel)
+    on every (re)start and a job landing mid-probe crashloops. Lock both
+    in so a refactor can't silently regress them (Gitea
+    fallen-leaf/ansible-runner-image#15).
+    """
+    try:
+        with open(GITEA_RUNNER_TASKS) as fh:
+            text = fh.read()
+    except FileNotFoundError:
+        errors.append(f"{GITEA_RUNNER_TASKS}: File not found")
+        return
+
+    init_count = text.count("init: true")
+    if init_count < GITEA_RUNNER_INIT_MIN:
+        errors.append(
+            f"{GITEA_RUNNER_TASKS}: expected `init: true` on both "
+            f"docker_container deploy variants (found {init_count}, need "
+            f"{GITEA_RUNNER_INIT_MIN}); without docker-init as PID 1 the "
+            f"runner does not subreap dind job-container zombies. See Gitea "
+            f"fallen-leaf/ansible-runner-image#15."
+        )
+
+    if GITEA_RUNNER_DAEMON_JSON_MARKER not in text:
+        errors.append(
+            f"{GITEA_RUNNER_TASKS}: missing the "
+            f"{GITEA_RUNNER_DAEMON_JSON_MARKER} storage-driver pin mount; "
+            f"the inner dind dockerd must not auto-probe the DSM-broken "
+            f"overlay2/fuse-overlayfs drivers. See Gitea "
+            f"fallen-leaf/ansible-runner-image#15."
+        )
+
+
 def main():
     errors = []
     warnings = []
@@ -375,6 +427,10 @@ def main():
 
     # Run check G: tailscale_sidecar must fail fast on a dead TS_AUTHKEY (#25)
     check_g_tailscale_authkey_failfast(errors)
+
+    # Run check H: gitea_runner must run docker-init PID 1 + pin dind
+    # storage driver (Gitea fallen-leaf/ansible-runner-image#15)
+    check_h_gitea_runner_dind_hardening(errors)
 
     # Report results
     for w in warnings:


### PR DESCRIPTION
## Summary

The actual root cause of the CI runner crashloop / fleet-wide heartbeat flap (Gitea `fallen-leaf/ansible-runner-image#15`, which supersedes `jaxzin-infra-bootstrap#25`'s wrong "expired ephemeral Tailscale key" premise). Scope correction confirmed: the fix is **entirely in this repo's `gitea_runner` role**, not the ansible-runner-image repo.

Two defects, both verified against the **live `gitea-runner` container**:

1. **PID 1 = `s6-svscan`, not docker-init** — no `init:` on either `docker_container` task → dind job-container zombies never subreaped → zombie/conntrack/libnetwork accumulation starves the act_runner heartbeat → "both runners flap offline/online." Fix: `init: true` on both deploy variants (same fix class as obsidian-mcp's vault-sync `init: true`).

2. **Inner dind dockerd auto-probes a broken storage driver** — runs with no `--config-file`/`--storage-driver` and no `/etc/docker/daemon.json`, so on every (re)start it probes overlay2 (`no such device`) → fuse-overlayfs (`not found`) → btrfs on the DSM kernel; a job landing mid-probe crashloops. Fix: pin `storage-driver: btrfs` via a bind-mounted `daemon.json`.

### Evidence-driven deviation from ansible-runner-image#15's prescription

That issue prescribed forcing `storage-driver: vfs` on the belief that *no* driver works. **Live `docker info` on the runner shows the dind is currently on a working `btrfs` driver.** Forcing `vfs` would regress a healthy fast driver to the slowest one fleet-wide. The evidence-correct realization of the issue's intent ("don't let dockerd fall through broken drivers") is to **pin the empirically-working driver (btrfs)** so dockerd skips the fragile probe — not vfs.

## Lock-in

Check H added to `tests/check_docker_tasks.py` (same tests-as-architecture idiom as Checks F/G): asserts `init: true` on both variants + the `/etc/docker/daemon.json` pin mount, so a refactor can't silently regress either defect.

## Verification done locally
- `python3 tests/check_docker_tasks.py`: PASS (Check H green; A–G intact).
- `ansible-playbook tests/test-regression.yml`: green (`ok=32 failed=0`).
- Role YAML validated with `yq`; `init: true` ×2; daemon.json mount on both variants.

## Post-merge rollout (operator-aware)
Apply via the GitHub `Bootstrap` path (runs on a different runner from the broken Gitea act_runner, so the self-referential build-loop deadlock does not bind). Verification target: `docker exec gitea-runner ps` shows PID 1 = `docker-init`; a throwaway container starts clean in the dind; both runners stable-online ≥30 min; the queued obsidian-mcp vault-sync deploy dequeues and completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)