### PR TITLE
fix(gitea-runner): job-container ssh->tailnet via SOCKS5 (the real remaining #25 fix)

### DIFF
--- a/docs/runbooks/job-container-tailnet-ssh.md
+++ b/docs/runbooks/job-container-tailnet-ssh.md
@@ -1,0 +1,68 @@
+# Runbook: job-container ssh-to-tailnet (static SOCKS5 helper)
+
+## What this is
+
+Gitea #25 remaining defect: after the userspace-sidecar refactor
+(`1bd3b788`), a dind-spawned CI job container has **no tailnet route and
+no MagicDNS**. `ssh` does not honor `*_PROXY`, so a plain
+`ssh host.<tailnet>` (e.g. obsidian-mcp deploying to `gaming.<tailnet>`)
+resolves to public junk and fails `ENETUNREACH`.
+
+Fix: the `gitea_runner` role bind-mounts, into every job container:
+
+- a **static `socat`** at `/usr/local/bin/ts-socks5`
+- an ssh snippet at `/etc/ssh/ssh_config.d/10-tailnet-proxy.conf` that
+  sets `ProxyCommand` for `Host *.<tailnet>` to route through the
+  userspace Tailscale sidecar's SOCKS5 server (`tailscale-runner:1055`).
+
+socat sends the **hostname** to the SOCKS5 server, so the sidecar — which
+*is* on the tailnet — does the MagicDNS resolution **and** the routing.
+The job container resolves/routes nothing tailnet-side. Transparent to
+consumers (no obsidian-mcp change).
+
+## Required operator input (one-time, then on rotation)
+
+No download URL is shipped in the repo on purpose — silently fetching a
+binary that runs inside every CI job container is a supply-chain risk.
+The operator pins a trusted static `socat`:
+
+1. Obtain (or build) a **statically linked** `socat` for **linux/amd64**
+   (the runner label set is `amd64`; job images are glibc Ubuntu, but a
+   fully static binary runs regardless of libc). Verify it is static:
+   `file socat` → "statically linked"; `ldd socat` → "not a dynamic
+   executable".
+2. Record its download URL and SHA-256.
+3. Set both as CI **Secrets/Variables** consumed at deploy time
+   (env vars read in `gitea_runner/defaults/main.yml`):
+   - `GITEA_RUNNER_SOCKS_HELPER_URL`
+   - `GITEA_RUNNER_SOCKS_HELPER_SHA256`
+   Set them on **both** the GitHub repo and the Gitea mirror (this is the
+   bootstrap layer — see the layering rule).
+4. Trigger a deploy (`Bootstrap` workflow). The role asserts both are set
+   (fails fast with this runbook's name if not), `get_url` fetches with
+   `checksum: sha256:...` (deploy fails on mismatch — tamper-evident),
+   and bind-mounts it.
+
+## Verify end to end
+
+- Deploy is green; `gitea-runner` recreated with the two new
+  `-v ...ts-socks5...` / `...10-tailnet-proxy.conf...` mounts
+  (`docker inspect gitea-runner`).
+- Re-trigger the obsidian-mcp deploy. Its Ansible `PLAY RECAP` for
+  `gaming` shows `unreachable=0` (previously `unreachable=1`).
+- Spot check inside a job: `ssh -G gaming.<tailnet>` lists the
+  `proxycommand ... ts-socks5 ... SOCKS5:tailscale-runner:...:1055`.
+
+## Rotation / lifecycle
+
+Re-pin (URL + SHA-256) when upgrading the helper; the `checksum:` makes a
+changed artifact fail the deploy until the SHA is updated — intentional.
+Keep the binary static; a dynamically linked build will fail in minimal
+job images with an interpreter/libc error.
+
+## Why not vendor the binary in git / hardcode a URL
+
+Vendoring bloats the repo with a binary blob; hardcoding a URL means an
+unreviewed, unpinned binary executes in every CI job. The pinned
+URL+SHA-256 operator input is the same trust posture as the other
+bootstrap-layer CI secrets (e.g. `TS_AUTHKEY`).

--- a/playbooks/roles/gitea_runner/defaults/main.yml
+++ b/playbooks/roles/gitea_runner/defaults/main.yml
@@ -40,3 +40,24 @@ gitea_runner_proxy_env:
   HTTP_PROXY:  "http://{{ tailscale_runner_container_name }}:1099"
   ALL_PROXY:   "socks5://{{ tailscale_runner_container_name }}:1055"
   NO_PROXY:    "localhost,127.0.0.1,docker,host.docker.internal,{{ lan_domain_suffix }},tailscale-runner,gitea-db,gitea-runner"
+
+# --- Tailnet ssh path for dind job containers (Gitea #25) ---
+# `ssh` does NOT honor *_PROXY, so the proxy env above does not help jobs
+# that ssh to tailnet hosts (e.g. obsidian-mcp deploying to gaming.<tailnet>).
+# Post-userspace-refactor the job container has no tailnet route AND no
+# MagicDNS — gaming.<tailnet> resolves to public junk. Fix: give ssh a
+# ProxyCommand through the sidecar's SOCKS5 server, which (being on the
+# tailnet) does the MagicDNS resolution AND the routing. The upstream job
+# image (docker.gitea.com/runner-images:ubuntu-latest) ships no SOCKS
+# client, so we bind-mount a static `socat` + an ssh_config.d snippet into
+# every job container via config.yaml.j2 container.options.
+#
+# socat is fetched (pinned URL + sha256) rather than vendored as a binary
+# in git. Both MUST be set by the operator to a trusted static build (it
+# runs inside every CI job container) — see
+# docs/runbooks/job-container-tailnet-ssh.md. No default URL on purpose:
+# guessing a binary download is a supply-chain risk.
+gitea_runner_socks_helper_url: "{{ lookup('ansible.builtin.env', 'GITEA_RUNNER_SOCKS_HELPER_URL') | default('', true) }}"
+gitea_runner_socks_helper_sha256: "{{ lookup('ansible.builtin.env', 'GITEA_RUNNER_SOCKS_HELPER_SHA256') | default('', true) }}"
+gitea_runner_socks_helper_host_path: "{{ gitea_runner_config_file_parent }}/ts-socks5"
+gitea_runner_tailnet_ssh_config_host_path: "{{ gitea_runner_config_file_parent }}/10-tailnet-proxy.conf"

--- a/playbooks/roles/gitea_runner/tasks/main.yml
+++ b/playbooks/roles/gitea_runner/tasks/main.yml
@@ -78,6 +78,45 @@
   notify:
     - Restart Gitea runner
 
+# --- Tailnet ssh path for dind job containers (Gitea #25) ---
+# These two host files are bind-mounted read-only into every job container
+# (see container.options in templates/config.yaml.j2). Must exist before
+# the runner container starts so the mounts resolve.
+
+- name: Require a pinned static SOCKS5 helper for the job-container tailnet ssh path
+  assert:
+    that:
+      - gitea_runner_socks_helper_url | length > 0
+      - gitea_runner_socks_helper_sha256 | length > 0
+    fail_msg: >-
+      GITEA_RUNNER_SOCKS_HELPER_URL and GITEA_RUNNER_SOCKS_HELPER_SHA256 must
+      be set to a trusted static `socat` build — it runs inside every CI job
+      container to give `ssh` a SOCKS5 path to tailnet hosts (Gitea #25). No
+      default is shipped on purpose (guessing a binary download is a
+      supply-chain risk). See docs/runbooks/job-container-tailnet-ssh.md.
+    success_msg: "Static SOCKS5 helper source is pinned (url + sha256)."
+
+- name: Fetch the pinned static SOCKS5 helper (socat) to the runner host
+  ansible.builtin.get_url:
+    url: "{{ gitea_runner_socks_helper_url }}"
+    dest: "{{ gitea_runner_socks_helper_host_path }}"
+    checksum: "sha256:{{ gitea_runner_socks_helper_sha256 }}"
+    owner: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    group: "users"
+    mode: '0755'
+  notify:
+    - Restart Gitea runner
+
+- name: Template the tailnet ssh ProxyCommand config for job containers
+  template:
+    src: tailnet-ssh-proxy.conf.j2
+    dest: "{{ gitea_runner_tailnet_ssh_config_host_path }}"
+    owner: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+    group: "users"
+    mode: '0644'
+  notify:
+    - Restart Gitea runner
+
 # --- Runner container deployment (conditional on Tailscale) ---
 
 # Healthcheck used by both deploy variants below. Detects the s6 init wedge

--- a/playbooks/roles/gitea_runner/templates/config.yaml.j2
+++ b/playbooks/roles/gitea_runner/templates/config.yaml.j2
@@ -97,7 +97,12 @@ container:
   #   playbook to reconcile. See docs/architecture/tailscale-sidecar-modes.md
   #   for the quick-vs-permanent fix trade-off.
   # See fallen-leaf/ansible-runner-image#1.
-  options: "-v /certs/client:/certs/client:ro --add-host=docker:host-gateway --add-host=tailscale-runner:{{ tailscale_runner_gitea_net_ip }} -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client"
+  # The two ts-socks5 / ssh_config.d bind-mounts give `ssh` in job
+  # containers a SOCKS5 path to tailnet hosts via the userspace sidecar
+  # (Gitea #25). `ssh` ignores *_PROXY, and the job container has no
+  # tailnet route/MagicDNS, so without these a plain ssh to a tailnet
+  # host fails ENETUNREACH. See defaults/main.yml + the runbook.
+  options: "-v /certs/client:/certs/client:ro --add-host=docker:host-gateway --add-host=tailscale-runner:{{ tailscale_runner_gitea_net_ip }} -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client -v {{ gitea_runner_socks_helper_host_path }}:/usr/local/bin/ts-socks5:ro -v {{ gitea_runner_tailnet_ssh_config_host_path }}:/etc/ssh/ssh_config.d/10-tailnet-proxy.conf:ro"
   # The parent directory of a job's working directory.
   # NOTE: There is no need to add the first '/' of the path as act_runner will add it automatically.
   # If the path starts with '/', the '/' will be trimmed.

--- a/playbooks/roles/gitea_runner/templates/tailnet-ssh-proxy.conf.j2
+++ b/playbooks/roles/gitea_runner/templates/tailnet-ssh-proxy.conf.j2
@@ -1,0 +1,20 @@
+# Managed by jaxzin-infra-bootstrap gitea_runner role — DO NOT EDIT.
+# Bind-mounted read-only into every dind job container at
+# /etc/ssh/ssh_config.d/10-tailnet-proxy.conf (Ubuntu's openssh-client
+# /etc/ssh/ssh_config Includes ssh_config.d/*.conf).
+#
+# Why: `ssh` does not honor *_PROXY env vars, and post-userspace-refactor
+# a job container has no tailnet route and no MagicDNS — so a plain
+# `ssh host.<tailnet>` resolves to public junk and fails ENETUNREACH
+# (Gitea #25). This routes it through the userspace Tailscale sidecar's
+# SOCKS5 server instead. socat hands the *hostname* to the SOCKS5 server
+# (ATYP=domainname), so the sidecar — which IS on the tailnet — performs
+# the MagicDNS resolution AND the routing. The job container needs to
+# resolve nothing tailnet-side.
+#
+# tailscale-runner resolves inside the job container via the
+# --add-host=tailscale-runner:<gitea-net-ip> the runner already injects
+# (see container.options below in config.yaml.j2). :1055 = TS_SOCKS5_SERVER.
+Host *.{{ tailscale_tailnet }}
+    ProxyCommand /usr/local/bin/ts-socks5 - SOCKS5:{{ tailscale_runner_container_name }}:%h:%p,socksport=1055
+    StrictHostKeyChecking accept-new

--- a/tests/check_docker_tasks.py
+++ b/tests/check_docker_tasks.py
@@ -18,6 +18,10 @@ Checks:
      deploy variants) and pin the inner dind storage driver via a
      /etc/docker/daemon.json bind-mount (regression lock-in — see Gitea
      fallen-leaf/ansible-runner-image#15)
+  I) gitea_runner must give job containers an ssh->tailnet SOCKS5 path:
+     config.yaml.j2 container.options bind-mounts the static socat helper
+     and the ssh_config.d ProxyCommand snippet (regression lock-in — see
+     Gitea issue #25)
 
 Uses only Python stdlib — no PyYAML required.
 """
@@ -53,6 +57,22 @@ GITEA_RUNNER_TASKS = f"{ROLES_DIR}/gitea_runner/tasks/main.yml"
 # fallen-leaf/ansible-runner-image#15.
 GITEA_RUNNER_INIT_MIN = 2
 GITEA_RUNNER_DAEMON_JSON_MARKER = "/etc/docker/daemon.json"
+
+GITEA_RUNNER_CONFIG_TEMPLATE = f"{ROLES_DIR}/gitea_runner/templates/config.yaml.j2"
+GITEA_RUNNER_SSH_PROXY_TEMPLATE = f"{ROLES_DIR}/gitea_runner/templates/tailnet-ssh-proxy.conf.j2"
+# config.yaml.j2 container.options must bind-mount BOTH the static SOCKS5
+# helper and the ssh_config.d ProxyCommand snippet into job containers;
+# the snippet template must drive ssh through the sidecar's SOCKS5 server.
+# See Gitea issue #25.
+GITEA_RUNNER_SSH_PROXY_OPTION_MARKERS = (
+    ":/usr/local/bin/ts-socks5:ro",
+    ":/etc/ssh/ssh_config.d/10-tailnet-proxy.conf:ro",
+)
+GITEA_RUNNER_SSH_PROXY_TEMPLATE_MARKERS = (
+    "ProxyCommand",
+    "SOCKS5:",
+    "socksport=1055",
+)
 
 GITEA_HOST_PORTS_REQUIRED = [
     re.compile(r'^["\']?127\.0\.0\.1:.*:3000["\']?$'),
@@ -399,6 +419,53 @@ def check_h_gitea_runner_dind_hardening(errors):
         )
 
 
+def check_i_gitea_runner_job_tailnet_ssh(errors):
+    """Check I: job containers must get an ssh->tailnet SOCKS5 path.
+
+    `ssh` ignores *_PROXY and the dind job container has no tailnet
+    route/MagicDNS, so a plain `ssh host.<tailnet>` fails ENETUNREACH
+    (Gitea #25). The fix bind-mounts a static socat helper + an
+    ssh_config.d ProxyCommand snippet into every job container via
+    config.yaml.j2 container.options. Lock both surfaces in so a refactor
+    can't silently drop the #25 fix.
+    """
+    try:
+        with open(GITEA_RUNNER_CONFIG_TEMPLATE) as fh:
+            cfg = fh.read()
+    except FileNotFoundError:
+        errors.append(f"{GITEA_RUNNER_CONFIG_TEMPLATE}: File not found")
+        cfg = ""
+
+    miss_opt = [m for m in GITEA_RUNNER_SSH_PROXY_OPTION_MARKERS if m not in cfg]
+    if cfg and miss_opt:
+        errors.append(
+            f"{GITEA_RUNNER_CONFIG_TEMPLATE}: container.options missing job "
+            f"container ssh->tailnet mount(s) {miss_opt}; without the static "
+            f"SOCKS5 helper + ssh_config.d snippet, `ssh` to a tailnet host "
+            f"fails ENETUNREACH. See Gitea issue #25."
+        )
+
+    try:
+        with open(GITEA_RUNNER_SSH_PROXY_TEMPLATE) as fh:
+            tmpl = fh.read()
+    except FileNotFoundError:
+        errors.append(
+            f"{GITEA_RUNNER_SSH_PROXY_TEMPLATE}: File not found; the job "
+            f"container ssh ProxyCommand snippet is required for the Gitea "
+            f"#25 tailnet-ssh fix."
+        )
+        tmpl = ""
+
+    miss_t = [m for m in GITEA_RUNNER_SSH_PROXY_TEMPLATE_MARKERS if m not in tmpl]
+    if tmpl and miss_t:
+        errors.append(
+            f"{GITEA_RUNNER_SSH_PROXY_TEMPLATE}: missing marker(s) {miss_t}; "
+            f"the snippet must route ssh through the sidecar's SOCKS5 server "
+            f"(ProxyCommand ... SOCKS5: ... socksport=1055) so the tailnet "
+            f"side does MagicDNS + routing. See Gitea issue #25."
+        )
+
+
 def main():
     errors = []
     warnings = []
@@ -431,6 +498,9 @@ def main():
     # Run check H: gitea_runner must run docker-init PID 1 + pin dind
     # storage driver (Gitea fallen-leaf/ansible-runner-image#15)
     check_h_gitea_runner_dind_hardening(errors)
+
+    # Run check I: job containers must get an ssh->tailnet SOCKS5 path (#25)
+    check_i_gitea_runner_job_tailnet_ssh(errors)
 
     # Report results
     for w in warnings:

--- a/tests/test-regression.yml
+++ b/tests/test-regression.yml
@@ -221,6 +221,10 @@
         tailscale_runner_container_name: "tailscale-runner"
         tailscale_runner_gitea_net_ip: "172.20.0.42"
         lan_domain_suffix: ".lan.test.example"
+        # Job-container ssh->tailnet SOCKS5 mounts (Gitea #25). Synthetic
+        # host paths so the template renders without the real defaults.
+        gitea_runner_socks_helper_host_path: "/tmp/test/conf/ts-socks5"
+        gitea_runner_tailnet_ssh_config_host_path: "/tmp/test/conf/10-tailnet-proxy.conf"
         gitea_runner_proxy_env:
           HTTPS_PROXY: "http://tailscale-runner:1099"
           HTTP_PROXY: "http://tailscale-runner:1099"


### PR DESCRIPTION
## Summary

The evidenced remaining root cause of Gitea #25 (the part PR #99's crashloop fix did *not* solve). Found via systematic-debugging, evidence-complete:

- After the userspace-sidecar refactor (`1bd3b788`), a dind job container has **no tailnet route AND no MagicDNS** — the in-job diagnostic shows `gaming.<tailnet>` resolving to **public IPs** `209.177.145.x`, `tailscale0 ABSENT`. `ssh` ignores `*_PROXY`, so obsidian-mcp's plain `ssh gaming.<tailnet>` → `ENETUNREACH`.
- Verified the upstream job image `docker.gitea.com/runner-images:ubuntu-latest` ships **no SOCKS client** (no nc/ncat/socat/connect); OpenSSH 9.6 present but can't SOCKS alone.

## Fix (this repo only; obsidian-mcp untouched per constraint)

Deliver the SOCKS capability + wire ssh to it, all via the existing `gitea_runner` container.options injection:

- Pinned **static `socat`** (operator-set `GITEA_RUNNER_SOCKS_HELPER_URL` + `_SHA256`, asserted; no default — silently fetching a binary that runs in every CI job is a supply-chain risk, same posture as `TS_AUTHKEY`) + `get_url` with `checksum:`.
- `ssh_config.d` snippet: `Host *.<tailnet>` → `ProxyCommand` through the userspace sidecar's SOCKS5 (`tailscale-runner:1055`). socat sends the **hostname** (ATYP=domainname) so the tailnet-connected sidecar does MagicDNS **and** routing — the job container resolves/routes nothing tailnet-side.
- Both bind-mounted read-only into every job container.
- **Check I** locks both surfaces in (tests-as-architecture). CHECK 7 fixture extended so the template still renders under test.
- Runbook: `docs/runbooks/job-container-tailnet-ssh.md`.

## Verification done locally
- `python3 tests/check_docker_tasks.py`: PASS (Check I green; A–H intact).
- `ansible-playbook tests/test-regression.yml`: green (`ok=32 failed=0`, incl. CHECK 7 render).
- Role YAML validated with `yq`.

## Post-merge precondition (operator-only — does NOT close #25)
Pin a trusted static `socat` (URL + sha256, both GitHub + Gitea mirror) per the runbook, deploy, then re-run obsidian-mcp and confirm its `PLAY RECAP` for `gaming` shows `unreachable=0`. Until that e2e passes, #25 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)