### PR TITLE
fix(ci): wire GITEA_RUNNER_SOCKS_HELPER_* env into bootstrap (completes #100 / Gitea #25)

### DIFF
--- a/.github/workflows/common-bootstrap.yml
+++ b/.github/workflows/common-bootstrap.yml
@@ -34,6 +34,12 @@ jobs:
       GITEA_LAN_HOST: ${{ secrets.GITEA_LAN_HOST || secrets.MYGITEA_LAN_HOST }}
       GITEA_LAN_SSH_PORT: ${{ secrets.GITEA_LAN_SSH_PORT || secrets.MYGITEA_LAN_SSH_PORT }}
       LAN_DOMAIN_SUFFIX: ${{ secrets.LAN_DOMAIN_SUFFIX }}
+      # Non-secret (public ERNW release URL + its sha256) → Variables, not
+      # Secrets. Consumed by the gitea_runner role to fetch the static
+      # socat that gives job containers an ssh->tailnet SOCKS5 path
+      # (Gitea #25; see docs/runbooks/job-container-tailnet-ssh.md).
+      GITEA_RUNNER_SOCKS_HELPER_URL: ${{ vars.GITEA_RUNNER_SOCKS_HELPER_URL }}
+      GITEA_RUNNER_SOCKS_HELPER_SHA256: ${{ vars.GITEA_RUNNER_SOCKS_HELPER_SHA256 }}
       GITEA_RESTORE: ${{ inputs.recover }}
       B2_APPLICATION_KEY_ID: ${{ secrets.B2_APPLICATION_KEY_ID }}
       B2_APPLICATION_KEY: ${{ secrets.B2_APPLICATION_KEY }}


### PR DESCRIPTION
## Summary
PR #100 added the gitea_runner role logic reading `GITEA_RUNNER_SOCKS_HELPER_URL`/`_SHA256` from env, but `common-bootstrap.yml` never exported them — pin would be inert and the role's assert would always fire. This exports both from repo **Variables** (non-secret: a public ERNW static-toolbox release URL + its sha256).

Pinned (verified): `socat-1.7.4.4-x86_64` from ERNW static-toolbox `socat-v1.7.4.4` — `file` confirms static-pie x86-64; identity confirmed genuine socat; sha256 `19fd284b...efeb597` computed from the downloaded artifact. Repo Variables already set.

Completes the Gitea #25 job-container tailnet-ssh fix (PR #100). After merge: Bootstrap deploy fetches+mounts socat, then obsidian-mcp e2e (`gaming: unreachable=0`) confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)