### PR TITLE
fix(gitea-runner): socat/ssh-config mount from in-dind path (completes #25)

### DIFF
--- a/playbooks/roles/gitea_runner/defaults/main.yml
+++ b/playbooks/roles/gitea_runner/defaults/main.yml
@@ -61,3 +61,13 @@ gitea_runner_socks_helper_url: "{{ lookup('ansible.builtin.env', 'GITEA_RUNNER_S
 gitea_runner_socks_helper_sha256: "{{ lookup('ansible.builtin.env', 'GITEA_RUNNER_SOCKS_HELPER_SHA256') | default('', true) }}"
 gitea_runner_socks_helper_host_path: "{{ gitea_runner_config_file_parent }}/ts-socks5"
 gitea_runner_tailnet_ssh_config_host_path: "{{ gitea_runner_config_file_parent }}/10-tailnet-proxy.conf"
+# The *_host_path values above are NAS-host paths — correct for the
+# Ansible get_url/template tasks that create the files. But the
+# config.yaml.j2 container.options `-v` SOURCE is resolved by the inner
+# dind dockerd, whose filesystem IS the gitea-runner container, where the
+# conf dir is the host's gitea_runner_data_path mounted at /data (proven
+# by CONFIG_FILE=/data/conf/config.yml and the /certs/client precedent).
+# So the job-container mount source must be the in-runner path, NOT the
+# host path. Using the host path makes dind auto-create an empty dir.
+gitea_runner_socks_helper_indind_path: "/data/conf/ts-socks5"
+gitea_runner_tailnet_ssh_config_indind_path: "/data/conf/10-tailnet-proxy.conf"

--- a/playbooks/roles/gitea_runner/templates/config.yaml.j2
+++ b/playbooks/roles/gitea_runner/templates/config.yaml.j2
@@ -102,7 +102,7 @@ container:
   # (Gitea #25). `ssh` ignores *_PROXY, and the job container has no
   # tailnet route/MagicDNS, so without these a plain ssh to a tailnet
   # host fails ENETUNREACH. See defaults/main.yml + the runbook.
-  options: "-v /certs/client:/certs/client:ro --add-host=docker:host-gateway --add-host=tailscale-runner:{{ tailscale_runner_gitea_net_ip }} -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client -v {{ gitea_runner_socks_helper_host_path }}:/usr/local/bin/ts-socks5:ro -v {{ gitea_runner_tailnet_ssh_config_host_path }}:/etc/ssh/ssh_config.d/10-tailnet-proxy.conf:ro"
+  options: "-v /certs/client:/certs/client:ro --add-host=docker:host-gateway --add-host=tailscale-runner:{{ tailscale_runner_gitea_net_ip }} -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client -v {{ gitea_runner_socks_helper_indind_path }}:/usr/local/bin/ts-socks5:ro -v {{ gitea_runner_tailnet_ssh_config_indind_path }}:/etc/ssh/ssh_config.d/10-tailnet-proxy.conf:ro"
   # The parent directory of a job's working directory.
   # NOTE: There is no need to add the first '/' of the path as act_runner will add it automatically.
   # If the path starts with '/', the '/' will be trimmed.

--- a/tests/test-regression.yml
+++ b/tests/test-regression.yml
@@ -225,6 +225,10 @@
         # host paths so the template renders without the real defaults.
         gitea_runner_socks_helper_host_path: "/tmp/test/conf/ts-socks5"
         gitea_runner_tailnet_ssh_config_host_path: "/tmp/test/conf/10-tailnet-proxy.conf"
+        # config.yaml.j2 mounts use the in-dind path (resolved in the
+        # gitea-runner container), not the host path. See defaults/main.yml.
+        gitea_runner_socks_helper_indind_path: "/data/conf/ts-socks5"
+        gitea_runner_tailnet_ssh_config_indind_path: "/data/conf/10-tailnet-proxy.conf"
         gitea_runner_proxy_env:
           HTTPS_PROXY: "http://tailscale-runner:1099"
           HTTP_PROXY: "http://tailscale-runner:1099"


### PR DESCRIPTION
## Summary
Post-deploy verification of PR #100 caught a path-context bug: `container.options` `-v` sources are resolved by the **inner dind dockerd** (filesystem = the gitea-runner container, conf at `/data/conf`, per `CONFIG_FILE=/data/conf/config.yml` + the `/certs/client` precedent). #100 used the NAS-host path `/volume1/...` → dind auto-created an empty dir → job containers got a directory at `/usr/local/bin/ts-socks5` instead of the socat binary.

Fix: new `gitea_runner_*_indind_path` vars (`/data/conf/...`) used as the mount source; `*_host_path` vars retained for the Ansible get_url/template dest (host-side). CHECK 7 fixture extended. Check I unchanged (dest markers identical).

socat pin already verified+set (ERNW socat-v1.7.4.4 x86_64, sha `19fd284b…efeb597`); env wiring merged (#101).

## Verified locally
- `check_docker_tasks`: PASS. `ansible-playbook tests/test-regression.yml`: `ok=32 failed=0` (incl. CHECK 7 render with in-dind vars).

After merge: Bootstrap deploy → verify a JOB container actually gets the socat binary (not a dir) → obsidian-mcp e2e (`gaming: unreachable=0`) closes Gitea #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)