### PR TITLE
fix(gitea-runner): ssh ProxyCommand config root-owned (final #25 delivery fix)

### DIFF
--- a/playbooks/roles/gitea_runner/tasks/main.yml
+++ b/playbooks/roles/gitea_runner/tasks/main.yml
@@ -108,11 +108,17 @@
     - Restart Gitea runner
 
 - name: Template the tailnet ssh ProxyCommand config for job containers
+  # owner/group MUST be root: bind-mounted into job containers at
+  # /etc/ssh/ssh_config.d/10-tailnet-proxy.conf, OpenSSH strict-checks
+  # Included global config and requires st_uid==0 (or the running user).
+  # A host-uid-owned file → "Bad owner or permissions" → ssh discards the
+  # whole config → ProxyCommand never applies (Gitea #25). The playbook
+  # runs become: true, so chown to root succeeds.
   template:
     src: tailnet-ssh-proxy.conf.j2
     dest: "{{ gitea_runner_tailnet_ssh_config_host_path }}"
-    owner: "{{ ansible_user | default(lookup('env', 'USER')) }}"
-    group: "users"
+    owner: root
+    group: root
     mode: '0644'
   notify:
     - Restart Gitea runner


### PR DESCRIPTION
## Summary
4th/final delivery-layer fix for Gitea #25's job-container ssh→tailnet path. Prior layers fixed: env wiring (#101), in-dind mount path-context (#102). obsidian-mcp run #88's in-job diagnostic proved socat now mounts correctly (no more "is a directory"), but: `Bad owner or permissions on /etc/ssh/ssh_config.d/10-tailnet-proxy.conf` → OpenSSH strict-checks Included global config (needs `st_uid==0` or running user) → discards config → ProxyCommand never applies → `gaming unreachable=1`.

Fix: template the snippet `owner: root group: root` (playbook runs `become: true`). socat binary mount unaffected (ssh doesn't perm-check the ProxyCommand binary).

## Verified locally
- `check_docker_tasks`: PASS. `tests/test-regression.yml`: green.

After merge: Bootstrap deploy → obsidian-mcp e2e. If `PLAY RECAP gaming: unreachable=0`, Gitea #25 / ansible-runner-image#15 close. (Per the agreed hard-stop posture: if it fails for any *new* reason, stop and reconsider the delivery mechanism rather than attempt fix #5.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)