### PR TITLE
Bump act_runner 0.2.12 → 0.6.1 + collapse default values to a single source (defaults/main.yml)

### DIFF
--- a/docs/runbooks/gitea-runner-host.md
+++ b/docs/runbooks/gitea-runner-host.md
@@ -110,7 +110,7 @@ After `bootstrap-runner.sh`:
 |---|---|---|
 | `GITEA_RUNNER_HOST` | Secret | Only a human-readable inventory label now (the tailnet name). Kept a Secret as it contains the tailnet. |
 | `GITEA_RUNNER_DATA_PATH` | Variable | *(optional)* Override `/opt/gitea-runner` (also change the CI job mount + re-run the seed). |
-| `GITEA_RUNNER_IMAGE` | Variable | *(optional)* Override the act_runner image (default `gitea/act_runner:0.2.12`, **non-dind**). |
+| `GITEA_RUNNER_IMAGE` | Variable | *(optional)* Override the act_runner image (default `gitea/act_runner:0.6.1`, **non-dind** — pinned for DR reproducibility; bump deliberately). |
 | `GITEA_RUNNER_NAME` | Variable | *(optional)* Display name (default `gitea-runner`). |
 
 There is intentionally **no `GITEA_RUNNER_SSH_KEY`** and the connection is

--- a/docs/runbooks/gitea-runner-host.md
+++ b/docs/runbooks/gitea-runner-host.md
@@ -109,9 +109,9 @@ After `bootstrap-runner.sh`:
 | Name | Kind | Purpose |
 |---|---|---|
 | `GITEA_RUNNER_HOST` | Secret | Only a human-readable inventory label now (the tailnet name). Kept a Secret as it contains the tailnet. |
-| `GITEA_RUNNER_DATA_PATH` | Variable | *(optional)* Override `/opt/gitea-runner` (also change the CI job mount + re-run the seed). |
-| `GITEA_RUNNER_IMAGE` | Variable | *(optional)* Override the act_runner image (default `gitea/act_runner:0.6.1`, **non-dind** — pinned for DR reproducibility; bump deliberately). |
-| `GITEA_RUNNER_NAME` | Variable | *(optional)* Display name (default `gitea-runner`). |
+| `GITEA_RUNNER_DATA_PATH` | Variable | *(optional)* Override the fixed host data dir (also change the CI job mount + re-run the seed). Pinned default: see the role's `playbooks/roles/gitea_runner/defaults/main.yml`. |
+| `GITEA_RUNNER_IMAGE` | Variable | *(optional)* Override the act_runner image (non-dind; pinned for DR reproducibility, bump deliberately). Pinned default: see `playbooks/roles/gitea_runner/defaults/main.yml`. |
+| `GITEA_RUNNER_NAME` | Variable | *(optional)* Override the runner's display name. Default: see `playbooks/roles/gitea_runner/defaults/main.yml`. |
 
 There is intentionally **no `GITEA_RUNNER_SSH_KEY`** and the connection is
 **local**, not SSH/Tailscale SSH. `GITEA_RUNNER_SSH_USER`, if you set it

--- a/playbooks/roles/gitea_runner/defaults/main.yml
+++ b/playbooks/roles/gitea_runner/defaults/main.yml
@@ -49,7 +49,7 @@ gitea_runner_config_file: "{{ gitea_runner_config_file_parent }}/config.yml"
 # zombie subreaping, dind-DNS gap, certs-volume mismatch).
 gitea_runner_image: >-
   {{ lookup('ansible.builtin.env', 'GITEA_RUNNER_IMAGE')
-     | default('gitea/act_runner:0.2.12', true) }}
+     | default('gitea/act_runner:0.6.1', true) }}
 
 # Display name the runner registers under. Host-neutral default; override
 # per host via the GITEA_RUNNER_NAME CI variable if you run more than one.

--- a/playbooks/roles/gitea_runner/defaults/main.yml
+++ b/playbooks/roles/gitea_runner/defaults/main.yml
@@ -25,6 +25,11 @@
 # Anything host-specific (paths, OS package management, kernel quirks) is
 # the caller's concern, injected via the variables below — never hardcoded
 # in this role.
+#
+# THIS FILE IS THE SINGLE SOURCE OF TRUTH for gitea_runner default
+# VALUES. meta/main.yml documents type/usage only — Ansible arg-spec
+# default keys are doc-only (never applied at runtime), so restating a
+# value there would just drift. Do not duplicate these literals.
 
 # Where the runner keeps its registration + config + cache. This is a
 # FIXED HOST path, never a per-user ~ dir: in the co-located bootstrap

--- a/playbooks/roles/gitea_runner/meta/main.yml
+++ b/playbooks/roles/gitea_runner/meta/main.yml
@@ -34,7 +34,7 @@ argument_specs:
           the host's kernel-mode Tailscale.
       gitea_runner_image:
         type: "str"
-        default: "gitea/act_runner:0.2.12"
+        default: "gitea/act_runner:0.6.1"
         description: "Plain (non-dind) act_runner image."
       gitea_runner_name:
         type: "str"

--- a/playbooks/roles/gitea_runner/meta/main.yml
+++ b/playbooks/roles/gitea_runner/meta/main.yml
@@ -32,26 +32,39 @@ argument_specs:
           URL the runner CONTAINER connects to Gitea on at runtime (the
           tailnet Serve URL, e.g. https://gitea.<tailnet>), reached via
           the host's kernel-mode Tailscale.
+      # NOTE: argument_specs default keys are documentation-only in
+      # Ansible (the runtime value always comes from defaults/main.yml).
+      # To keep ONE source of truth and avoid drift, this spec declares
+      # NO default values — it documents type/usage and points to
+      # defaults/main.yml. A regression check enforces zero default keys
+      # here (tests/test-regression.yml CHECK 8).
       gitea_runner_image:
         type: "str"
-        default: "gitea/act_runner:0.6.1"
-        description: "Plain (non-dind) act_runner image."
+        description: >-
+          Plain (non-dind) act_runner image. The pinned default and the
+          GITEA_RUNNER_IMAGE env override are defined in the role's
+          defaults/main.yml (the single source of default values).
       gitea_runner_name:
         type: "str"
-        default: "gitea-runner"
-        description: "Display name the runner registers under."
+        description: >-
+          Display name the runner registers under. The default and the
+          GITEA_RUNNER_NAME env override are defined in defaults/main.yml.
       gitea_runner_data_path:
         type: "str"
         description: >-
-          FIXED host directory for runner state (default /opt/gitea-runner).
-          Never a ~ path: the role runs in the CI container (connection:
-          local) and the host Docker daemon bind-mounts this same host
-          path into the runner container, so it must be coherent across
-          both (the CI job bind-mounts it; bootstrap-runner.sh provisions
-          it).
+          FIXED host directory for runner state. Never a ~ path: the role
+          runs in the CI container (connection: local) and the host Docker
+          daemon bind-mounts this same host path into the runner
+          container, so it must be coherent across both (the CI job
+          bind-mounts it; bootstrap-runner.sh provisions it). The default
+          and the GITEA_RUNNER_DATA_PATH env override are defined in
+          defaults/main.yml.
       gitea_runner_config_file_parent:
         type: "str"
-        default: "{{ gitea_runner_data_path }}/conf"
+        description: >-
+          Derived from gitea_runner_data_path; defined in defaults/main.yml.
       gitea_runner_config_file:
         type: "str"
-        default: "{{ gitea_runner_config_file_parent }}/config.yml"
+        description: >-
+          Derived from gitea_runner_config_file_parent; defined in
+          defaults/main.yml.

--- a/tests/test-regression.yml
+++ b/tests/test-regression.yml
@@ -290,6 +290,11 @@
         src: "{{ roles_dir }}/gitea_runner/tasks/main.yml"
       register: runner_tasks_raw
 
+    - name: "CHECK 8: Read gitea_runner role meta"
+      slurp:
+        src: "{{ roles_dir }}/gitea_runner/meta/main.yml"
+      register: runner_meta_raw
+
     - name: "CHECK 8: Read bootstrap-runner.sh"
       slurp:
         src: "{{ project_root }}/bootstrap-runner.sh"
@@ -311,6 +316,7 @@
         gitea_deploy: "{{ gitea_deploy_raw.content | b64decode }}"
         runner_defaults: "{{ runner_defaults_raw.content | b64decode }}"
         runner_tasks: "{{ runner_tasks_raw.content | b64decode }}"
+        runner_meta: "{{ runner_meta_raw.content | b64decode }}"
         bootstrap_runner: "{{ bootstrap_runner_raw.content | b64decode }}"
         runner_runbook: "{{ runner_runbook_raw.content | b64decode }}"
         readme: "{{ readme_raw.content | b64decode }}"
@@ -343,6 +349,23 @@
           connection:local a ~ path resolves to the CI container FS, not
           the host FS the runner container bind-mounts (the classic
           bind-source bug). See defaults/main.yml comment.
+
+    - name: "CHECK 8: Assert meta arg-spec is doc-only (no default values; single source = defaults/main.yml)"
+      assert:
+        that:
+          # Ansible argument_specs `default:` is documentation-only and is
+          # never applied at runtime — restating values here just drifts
+          # from defaults/main.yml (the single source of truth). The spec
+          # must declare type/required/description only. (The word
+          # "default" may appear in description prose, but the literal
+          # `default:` KEY must not.)
+          - "'default:' not in runner_meta"
+        fail_msg: >
+          playbooks/roles/gitea_runner/meta/main.yml reintroduced a
+          `default:` key. argument_specs defaults are doc-only in Ansible;
+          the single source of default VALUES is
+          playbooks/roles/gitea_runner/defaults/main.yml. Remove the
+          default from meta and document it by pointing to defaults/main.yml.
 
     - name: "CHECK 8: Assert the registration token is minted in Play 1, not the role"
       assert:


### PR DESCRIPTION
## Summary

The act_runner pin (`gitea/act_runner:0.2.12`) carried over stale from the old NAS `0.2.12-dind` config. Verified against Docker Hub: `:latest` digest == `:0.6.1`; `0.2.12` is several minor releases behind. Keep it **pinned** (DR reproducibility — the established convention) but **current**. Override remains available via the `GITEA_RUNNER_IMAGE` CI variable.

Changed: role default, meta arg-spec default, runbook CI table. (The `0.2.12-dind` mention in `docs/plans/2026-05-15-*` is a historical point-in-time record — intentionally left.)

## Validation plan

0.2→0.6 is a large jump (act_runner config/`.runner` schema may have changed), so this is validated by **running Bootstrap from this branch before merge** (same pattern as #104), confirming the recreated `gitea-runner` (a) starts on 0.6.1, (b) registers/declares with Gitea, (c) a job runs. Not merging on faith.

- [x] `check_docker_tasks.py` 0 errors
- [x] `test-regression.yml` failed=0 (ok=45)
- [ ] Bootstrap-from-branch: gaming `gitea-runner` recreated on 0.6.1, Online, job runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)