### PR TITLE
fix(tailscale-sidecar): restore 127.0.0.11 after tailscaled writes resolv.conf

### DIFF
--- a/playbooks/roles/tailscale_sidecar/tasks/main.yml
+++ b/playbooks/roles/tailscale_sidecar/tasks/main.yml
@@ -36,17 +36,16 @@
     networks:
       - name: "{{ tailscale_network_name }}"
     ports: "{{ tailscale_host_ports | default([], true) }}"
-    # When tailscale_accept_dns is false, tailscaled won't configure the
-    # container's DNS, so Docker's embedded resolver (127.0.0.11) would be
-    # used — which doesn't know tailnet names. Explicitly set 100.100.100.100
-    # (MagicDNS) so the container can still resolve tailnet hostnames.
-    # IMPORTANT: with tailscale_accept_dns=false, tailscaled does NOT wire an
-    # upstream forwarder for 100.100.100.100, so external names (e.g.
-    # acme-v02.api.letsencrypt.org) will SERVFAIL. If the sidecar needs both
-    # tailnet AND external resolution (e.g. for ACME cert renewal or OIDC
-    # back-channel calls), use tailscale_accept_dns=true instead so the
-    # tailnet's global nameservers are applied as upstream forwarders.
-    dns_servers: "{{ ['100.100.100.100'] if not (tailscale_accept_dns | default(true) | bool) else omit }}"
+    # Always set 100.100.100.100 so Docker's embedded resolver (127.0.0.11)
+    # has MagicDNS as its upstream. When tailscale_accept_dns=false, tailscaled
+    # does not write resolv.conf, so 127.0.0.11 stays active and forwards
+    # unknown names to 100.100.100.100 (tailnet names resolve; external names
+    # SERVFAIL because accept_dns=false skips wiring Cloudflare as upstream).
+    # When tailscale_accept_dns=true, tailscaled writes resolv.conf and removes
+    # 127.0.0.11; a post-start task restores it so Docker service names AND
+    # tailnet/external names all resolve: Docker names → 127.0.0.11; everything
+    # else → 127.0.0.11 → 100.100.100.100 → Cloudflare. (2026-05-25 incident)
+    dns_servers: "['100.100.100.100']"
     # Kernel-mode Tailscale needs CAP_NET_ADMIN + CAP_SYS_MODULE plus the
     # /dev/net/tun device to bring up its kernel TUN interface. Userspace
     # mode (TS_USERSPACE=true) routes WireGuard packets entirely in user
@@ -139,3 +138,23 @@
       Tailscale sidecar '{{ tailscale_container_name }}' is Running with a
       usable tailnet route ({{ ts_state.Peer | default({}) | length }} peers).
   when: tailscale_enabled | bool and not ansible_check_mode
+
+- name: Restore Docker embedded DNS resolver in Tailscale sidecar resolv.conf
+  # tailscaled (TS_ACCEPT_DNS=true) writes resolv.conf and removes Docker's
+  # embedded resolver (127.0.0.11). Without it, containers sharing this netns
+  # (e.g. gitea via network_mode:container:) cannot resolve Docker service
+  # names like gitea-db, causing DB-connection failures on every deploy.
+  # Prepend 127.0.0.11; its upstream is 100.100.100.100 (wired via dns_servers
+  # at container start), which tailscaled connects to Cloudflare — so the full
+  # chain works: Docker names → 127.0.0.11; tailnet/external names →
+  # 127.0.0.11 → 100.100.100.100 → Cloudflare. Idempotent: grep exits 0 and
+  # sed is skipped if 127.0.0.11 is already present. (2026-05-25 incident)
+  community.docker.docker_container_exec:
+    container: "{{ tailscale_container_name }}"
+    command: >-
+      sh -c "grep -q '^nameserver 127.0.0.11' /etc/resolv.conf ||
+             sed -i '1s/^/nameserver 127.0.0.11\n/' /etc/resolv.conf"
+  changed_when: false
+  when: >
+    tailscale_enabled | bool and not ansible_check_mode and
+    (tailscale_accept_dns | default(true) | bool)

--- a/tests/test-regression.yml
+++ b/tests/test-regression.yml
@@ -614,6 +614,35 @@
           blocks Gitea (tier-1/DR-first) from coming up.
 
     # ================================================================
+    # Check 14: Tailscale sidecar restores Docker embedded DNS resolver
+    #           (127.0.0.11) after tailscaled writes resolv.conf.
+    # ================================================================
+    # With tailscale_accept_dns=true, tailscaled writes resolv.conf and
+    # removes Docker's 127.0.0.11. Without it, containers sharing the
+    # sidecar's netns (e.g. gitea via network_mode:container:) can't
+    # resolve Docker service names like gitea-db, causing DB failures.
+    # The role must: (a) always set dns_servers=['100.100.100.100']
+    # unconditionally (not gated on tailscale_accept_dns) so 127.0.0.11's
+    # upstream is MagicDNS, and (b) inject 127.0.0.11 back after tailscaled
+    # writes resolv.conf when tailscale_accept_dns=true. (2026-05-25 incident)
+    - name: "CHECK 14: Assert tailscale_sidecar restores 127.0.0.11 in resolv.conf"
+      assert:
+        that:
+          - "'nameserver 127.0.0.11' in tailscale_sidecar_tasks"
+          - "'Restore Docker embedded DNS resolver' in tailscale_sidecar_tasks"
+          # The OLD dns_servers was a Jinja2 inline-if gated on tailscale_accept_dns;
+          # the new form is an unconditional literal list. Absence of the old
+          # inline-if fragment proves the conditional form was removed.
+          - "'if not (tailscale_accept_dns' not in tailscale_sidecar_tasks"
+        fail_msg: >
+          tailscale_sidecar/tasks/main.yml must: (1) set dns_servers unconditionally
+          to the literal list (no inline-if on tailscale_accept_dns — old conditional
+          form is banned), and (2) have a task named 'Restore Docker embedded DNS
+          resolver' that injects 'nameserver 127.0.0.11' back after tailscaled writes
+          resolv.conf. Without this, deploy fails with "nc: bad address 'gitea-db'"
+          (2026-05-25 incident).
+
+    # ================================================================
     # Cleanup
     # ================================================================
     - name: Clean up rendered test files


### PR DESCRIPTION
## Summary

- **Root cause**: `TS_ACCEPT_DNS=true` (required for ACME cert renewal, PR #114) causes tailscaled to overwrite `/etc/resolv.conf`, removing Docker's embedded resolver `127.0.0.11`. Without it, containers sharing the sidecar's netns (`gitea` via `network_mode:container:`) cannot resolve Docker service names like `gitea-db` — causing every deploy to fail with `"nc: bad address 'gitea-db'"` (2026-05-25 deploy failure).
- **Fix 1**: `dns_servers` changed from a Jinja2 inline-if gated on `tailscale_accept_dns` to an unconditional `['100.100.100.100']`, so Docker's `127.0.0.11` always has MagicDNS as its upstream in both modes.
- **Fix 2**: New post-start task "Restore Docker embedded DNS resolver" prepends `nameserver 127.0.0.11` back into resolv.conf after tailscaled writes it (when `tailscale_accept_dns=true`). Idempotent: grep-guarded no-op if already present.
- **CHECK 14** added to the regression suite locks in both invariants.

## Resolution chain

```
gitea-db (Docker service name)  →  127.0.0.11  →  answers directly
auth.<tailnet>.ts.net           →  127.0.0.11  →  100.100.100.100 (MagicDNS)  →  answers
acme-v02.api.letsencrypt.org    →  127.0.0.11  →  100.100.100.100  →  Cloudflare  →  answers
```

## Test plan

- [x] `make test` passes all 14 checks locally
- [ ] Deploy main after merge and verify `gitea-db` healthcheck succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)