### PR TITLE
fix(tailscale-sidecar): use in-place write instead of sed -i for resolv.conf

### DIFF
--- a/playbooks/roles/tailscale_sidecar/tasks/main.yml
+++ b/playbooks/roles/tailscale_sidecar/tasks/main.yml
@@ -147,13 +147,17 @@
   # Prepend 127.0.0.11; its upstream is 100.100.100.100 (wired via dns_servers
   # at container start), which tailscaled connects to Cloudflare — so the full
   # chain works: Docker names → 127.0.0.11; tailnet/external names →
-  # 127.0.0.11 → 100.100.100.100 → Cloudflare. Idempotent: grep exits 0 and
-  # sed is skipped if 127.0.0.11 is already present. (2026-05-25 incident)
+  # 127.0.0.11 → 100.100.100.100 → Cloudflare. (2026-05-25 incident)
+  # IMPORTANT: must NOT use `sed -i` — Docker bind-mounts resolv.conf at
+  # the file inode level; sed -i calls rename() which fails with EBUSY on
+  # bind-mount targets. Stage through /tmp then overwrite in-place with `>`
+  # (open+truncate, no rename). Idempotent: no-op if 127.0.0.11 already present.
   community.docker.docker_container_exec:
     container: "{{ tailscale_container_name }}"
     command: >-
       sh -c "grep -q '^nameserver 127.0.0.11' /etc/resolv.conf ||
-             sed -i '1s/^/nameserver 127.0.0.11\n/' /etc/resolv.conf"
+             { { echo 'nameserver 127.0.0.11'; cat /etc/resolv.conf; } > /tmp/resolv_new &&
+             cat /tmp/resolv_new > /etc/resolv.conf; }"
   changed_when: false
   when: >
     tailscale_enabled | bool and not ansible_check_mode and


### PR DESCRIPTION
## Summary

Follow-up to #115: the `sed -i` command used to prepend `127.0.0.11` fails because Docker bind-mounts `/etc/resolv.conf` at the file inode level, and `sed -i` relies on `rename()` to atomically swap the temp file into place. Linux returns `EBUSY` on bind-mount targets:

```
sed: can't move '/etc/resolv.confNEHiPK' to '/etc/resolv.conf': Resource busy
```

**Fix**: stage the new content into `/tmp/resolv_new`, then overwrite `/etc/resolv.conf` in-place using `cat > /etc/resolv.conf` (`open+truncate`, no `rename` call). This is exactly how tailscaled itself writes the file.

The logic is otherwise identical to #115: idempotent grep guard, `echo "nameserver 127.0.0.11"` prepended before the original content.

## Test plan

- [x] `make test` passes all 14 checks locally
- [ ] Deploy main after merge and verify the inject task succeeds and `gitea-db` healthcheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)