### PR TITLE
fix(tailscale-sidecar): self-heal resolv.conf via healthcheck (durable across restarts)

### DIFF
--- a/playbooks/roles/tailscale_sidecar/tasks/main.yml
+++ b/playbooks/roles/tailscale_sidecar/tasks/main.yml
@@ -42,10 +42,33 @@
     # unknown names to 100.100.100.100 (tailnet names resolve; external names
     # SERVFAIL because accept_dns=false skips wiring Cloudflare as upstream).
     # When tailscale_accept_dns=true, tailscaled writes resolv.conf and removes
-    # 127.0.0.11; a post-start task restores it so Docker service names AND
-    # tailnet/external names all resolve: Docker names → 127.0.0.11; everything
-    # else → 127.0.0.11 → 100.100.100.100 → Cloudflare. (2026-05-25 incident)
+    # 127.0.0.11; the post-start task below restores it so Docker service names
+    # AND tailnet/external names all resolve: Docker names → 127.0.0.11;
+    # everything else → 127.0.0.11 → 100.100.100.100 → Cloudflare.
+    # (2026-05-25 incident)
     dns_servers: "['100.100.100.100']"
+    # Self-healing DNS reconciler. The post-start task fixes resolv.conf ONCE,
+    # at deploy time — but tailscaled rewrites resolv.conf and strips 127.0.0.11
+    # on EVERY restart (container/daemon/host bounce, tailnet reconnect), which
+    # silently breaks gitea-db resolution between deploys (2026-06-05 incident:
+    # a ContainerManager restart re-triggered the bug). A Docker healthcheck
+    # runs on a fixed interval forever and may have side effects, so it doubles
+    # as a reconcile loop: re-prepend 127.0.0.11 whenever it's missing, then
+    # report healthy iff it's present. Same in-place write as the post-start
+    # task (open+truncate via >, never `sed -i`/rename — EBUSY on the bind
+    # mount). gitea's 10×3s DB-retry loop covers the ≤interval repair window.
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          grep -q '^nameserver 127.0.0.11' /etc/resolv.conf ||
+          { { echo 'nameserver 127.0.0.11'; cat /etc/resolv.conf; } > /tmp/resolv_new &&
+          cat /tmp/resolv_new > /etc/resolv.conf; };
+          grep -q '^nameserver 127.0.0.11' /etc/resolv.conf
+      interval: "{{ tailscale_resolv_heal_interval | default('15s') }}"
+      timeout: "{{ tailscale_resolv_heal_timeout | default('10s') }}"
+      retries: "{{ tailscale_resolv_heal_retries | default(3) }}"
+      start_period: "{{ tailscale_resolv_heal_start_period | default('10s') }}"
     # Kernel-mode Tailscale needs CAP_NET_ADMIN + CAP_SYS_MODULE plus the
     # /dev/net/tun device to bring up its kernel TUN interface. Userspace
     # mode (TS_USERSPACE=true) routes WireGuard packets entirely in user

--- a/playbooks/roles/tailscale_sidecar/tasks/main.yml
+++ b/playbooks/roles/tailscale_sidecar/tasks/main.yml
@@ -147,13 +147,17 @@
   # Prepend 127.0.0.11; its upstream is 100.100.100.100 (wired via dns_servers
   # at container start), which tailscaled connects to Cloudflare — so the full
   # chain works: Docker names → 127.0.0.11; tailnet/external names →
-  # 127.0.0.11 → 100.100.100.100 → Cloudflare. Idempotent: grep exits 0 and
-  # sed is skipped if 127.0.0.11 is already present. (2026-05-25 incident)
+  # 127.0.0.11 → 100.100.100.100 → Cloudflare. (2026-05-25 incident)
+  # IMPORTANT: must NOT use `sed -i` — Docker bind-mounts resolv.conf at
+  # the file inode level; sed -i calls rename() which fails with EBUSY on
+  # bind-mount targets. Stage through /tmp then overwrite in-place with `>`
+  # (open+truncate, no rename). Idempotent: no-op if 127.0.0.11 already present.
   community.docker.docker_container_exec:
     container: "{{ tailscale_container_name }}"
     command: >-
       sh -c "grep -q '^nameserver 127.0.0.11' /etc/resolv.conf ||
-             sed -i '1s/^/nameserver 127.0.0.11\n/' /etc/resolv.conf"
+             { { echo 'nameserver 127.0.0.11'; cat /etc/resolv.conf; } > /tmp/resolv_new &&
+             cat /tmp/resolv_new > /etc/resolv.conf; }"
   changed_when: false
   when: >
     tailscale_enabled | bool and not ansible_check_mode and

--- a/tests/test-regression.yml
+++ b/tests/test-regression.yml
@@ -643,6 +643,36 @@
           (2026-05-25 incident).
 
     # ================================================================
+    # Check 15: Tailscale sidecar self-heals resolv.conf continuously,
+    #           not just at deploy time.
+    # ================================================================
+    # The CHECK 14 post-start task fixes resolv.conf ONCE per deploy, but
+    # tailscaled strips 127.0.0.11 on every restart (container/daemon/host
+    # bounce, tailnet reconnect), so it silently re-breaks between deploys
+    # (2026-06-05 incident: a Synology ContainerManager restart re-triggered
+    # the bug; gitea then failed DB resolution with "lookup gitea-db ...
+    # no such host"). The durable fix is a Docker healthcheck on the sidecar
+    # that re-asserts 127.0.0.11 on a fixed interval forever and reports
+    # healthy iff it's present — a reconcile loop, not a one-shot. This check
+    # locks in that the healthcheck exists AND carries the reconcile write
+    # (presence of 'healthcheck:' alone is insufficient — it must repair).
+    - name: "CHECK 15: Assert tailscale_sidecar healthcheck self-heals resolv.conf"
+      assert:
+        that:
+          - "'healthcheck:' in tailscale_sidecar_tasks"
+          # The healthcheck must carry the in-place reconcile write, proving it
+          # repairs rather than merely probing. The redirect to /tmp/resolv_new
+          # is the signature of the open+truncate (non-rename) write pattern.
+          - "'/tmp/resolv_new' in tailscale_sidecar_tasks"
+        fail_msg: >
+          tailscale_sidecar/tasks/main.yml must have a Docker healthcheck on the
+          sidecar that continuously reconciles resolv.conf (re-prepends
+          'nameserver 127.0.0.11' via the /tmp/resolv_new open+truncate write,
+          never 'sed -i'). Without a continuous reconciler the deploy-time fix is
+          stripped on the next tailscaled restart and gitea loses gitea-db
+          resolution (2026-06-05 incident).
+
+    # ================================================================
     # Cleanup
     # ================================================================
     - name: Clean up rendered test files


### PR DESCRIPTION
## Why

The deploy-time `Restore Docker embedded DNS resolver` task fixes `resolv.conf` **once per ansible run**. But `tailscaled` (`TS_ACCEPT_DNS=true`, required to wire Cloudflare as MagicDNS upstream) rewrites `resolv.conf` and strips Docker's embedded resolver (`127.0.0.11`) on **every** restart — container/daemon/host bounce or tailnet reconnect — so it silently re-breaks between deploys.

**2026-06-05 incident:** a Synology ContainerManager restart (to clear a locked `db` log driver) bounced `tailscaled`, which stripped `127.0.0.11`. `gitea`, sharing the sidecar netns via `network_mode:container:`, then failed DB init with:

```
ORM engine initialization attempt #1/10 failed.
Error: dial tcp: lookup gitea-db on 100.100.100.100:53: no such host
```

## Fix

A Docker **healthcheck on the sidecar that doubles as a reconcile loop**: every 15s it re-prepends `127.0.0.11` if missing (same `/tmp/resolv_new` open+truncate write as the post-start task — never `sed -i`, which `EBUSY`s on the bind-mounted `resolv.conf`), then reports healthy iff present.

Deploy-time task and healthcheck are **complementary**: the task gives instant correctness at deploy, the healthcheck maintains it through every restart in between. Gitea's 10×3s DB-retry loop covers the sub-interval repair window.

Tunables: `tailscale_resolv_heal_{interval,timeout,retries,start_period}` (defaults `15s/10s/3/10s`).

## Test

- Adds regression **CHECK 15** — fails CI if the healthcheck or its reconcile write is ever removed.
- Local: regression suite **64/64 pass**, playbook syntax-check clean.

## Going live

Healthchecks are create-time only (can't be hot-added), so this takes effect when the deploy pipeline **recreates the sidecar**. Until then the running NAS container is patched manually and will lose `127.0.0.11` on the next `tailscaled` restart — merge + deploy makes it durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)