### PR TITLE
fix(gitea-runner): shared-host-safe tailnet DNS + fold runner host into IaC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ tofu/**/*.tfvars
 # Local-only planning artifacts (brainstorming specs / implementation plans).
 # Kept out of this public repo; they reference internal host/network details.
 docs/superpowers/
+
+# Local Claude Code agent state (worktrees, settings) — never commit
+.claude/

--- a/docs/runbooks/gitea-runner-host.md
+++ b/docs/runbooks/gitea-runner-host.md
@@ -22,10 +22,34 @@ runner target are **different machines**, connected over SSH.
 Everything else is provided by the deploy:
 
 - **`runner_host_seed` role** installs Docker + the Docker SDK for Python,
-  joins the tailnet via the `TS_AUTHKEY` secret, and creates the data dir.
+  joins the tailnet via the `TS_AUTHKEY` secret (with **`--accept-dns=false`**
+  by default — see "Shared-host DNS" below), and creates the data dir. The
+  authkey is only required when the host is not already on the tailnet.
 - **`gitea_runner` role** is a pure consumer: it asserts Docker + tailnet
   are present (fails fast otherwise), then deploys + registers the
   socket-mounted act_runner container with an arch-derived label.
+
+## Shared-host DNS (why `--accept-dns=false`)
+
+The runner host may be **shared** with other services (e.g. a host that also
+runs a sensor/weather bridge resolving LAN names like `*.iot.<lan-domain>`).
+If Tailscale joins with `--accept-dns=true`, `tailscaled` **rewrites the
+host's `/etc/resolv.conf`** to MagicDNS and the host can lose resolution of
+its own LAN names — breaking those co-located services.
+
+So `runner_host_seed` joins with **`--accept-dns=false`** (var
+`runner_host_seed_accept_dns`, default `false`), leaving the host resolver
+untouched. The runner **container** then can't use MagicDNS to find
+`gitea.<tailnet>`, so the deploy **pins it**: Play 1 captures Gitea's tailnet
+IP (`tailscale ip -4` on the Gitea sidecar) and passes it as
+`gitea_runner_gitea_tailnet_ip`; the `gitea_runner` role adds a
+`gitea.<tailnet> -> <ip>` entry to the act_runner container's `/etc/hosts`.
+TLS still validates because the connection uses the hostname (Tailscale Serve
+cert matches).
+
+Set `runner_host_seed_accept_dns: true` only on a **dedicated** runner host
+whose tailnet split-DNS already covers its LAN domains (then the pin is
+unnecessary, though harmless).
 
 ## SSH access (one-time seed, IaC)
 

--- a/playbooks/gitea-deploy.yml
+++ b/playbooks/gitea-deploy.yml
@@ -149,7 +149,7 @@
 
     - name: Expose the Gitea tailnet IP to Play 2
       set_fact:
-        gitea_runner_gitea_tailnet_ip: "{{ gitea_tailnet_ip_result.stdout_lines | first | trim }}"
+        gitea_runner_gitea_tailnet_ip: "{{ gitea_tailnet_ip_result.stdout | trim }}"
       when:
         - not (lookup('ansible.builtin.env', 'GITEA_ACTIONS', default='') == 'true')
         - gitea_tailnet_ip_result.stdout | default('') | trim | length > 0

--- a/playbooks/gitea-deploy.yml
+++ b/playbooks/gitea-deploy.yml
@@ -133,6 +133,27 @@
         gitea_runner_registration_token: "{{ runner_reg_token_result.json.token }}"
       when: not (lookup('ansible.builtin.env', 'GITEA_ACTIONS', default='') == 'true')
 
+    # Capture Gitea's TAILNET IP from its sidecar so Play 2 can pin
+    # gitea.<tailnet> -> this IP in the runner container's /etc/hosts. This
+    # makes the runner reach Gitea without depending on the runner host
+    # running MagicDNS (the host joins with --accept-dns=false to protect
+    # its own LAN resolution — see runner_host_seed_accept_dns). failed_when
+    # false: if the IP can't be read the runner falls back to host MagicDNS.
+    - name: Capture the Gitea sidecar tailnet IP (for the runner /etc/hosts pin)
+      ansible.builtin.command:
+        cmd: "docker exec {{ tailscale_gitea_container_name }} tailscale ip -4"
+      register: gitea_tailnet_ip_result
+      changed_when: false
+      failed_when: false
+      when: not (lookup('ansible.builtin.env', 'GITEA_ACTIONS', default='') == 'true')
+
+    - name: Expose the Gitea tailnet IP to Play 2
+      set_fact:
+        gitea_runner_gitea_tailnet_ip: "{{ gitea_tailnet_ip_result.stdout_lines | first | trim }}"
+      when:
+        - not (lookup('ansible.builtin.env', 'GITEA_ACTIONS', default='') == 'true')
+        - gitea_tailnet_ip_result.stdout | default('') | trim | length > 0
+
     - name: Configure Gitea Backups
       # NOTE: This is a static import, not an include.
       # It runs before the playbook starts regardless of the order
@@ -201,6 +222,10 @@
   vars:
     gitea_runner_token: "{{ hostvars[groups['nas'][0]].gitea_runner_registration_token | default('') }}"
     runner_host_seed_tailscale_authkey: "{{ tailscale_authkey | default('') }}"
+    # Gitea's tailnet IP (captured in Play 1) → pinned in the runner
+    # container's /etc/hosts so it resolves gitea.<tailnet> without the host
+    # needing MagicDNS. Empty falls back to host DNS.
+    gitea_runner_gitea_tailnet_ip: "{{ hostvars[groups['nas'][0]].gitea_runner_gitea_tailnet_ip | default('') }}"
     in_gitea: "{{ lookup('ansible.builtin.env', 'GITEA_ACTIONS', default='') == 'true' }}"
 
   tasks:

--- a/playbooks/roles/gitea_runner/defaults/main.yml
+++ b/playbooks/roles/gitea_runner/defaults/main.yml
@@ -11,15 +11,15 @@
 # only things this role depends on — are documented in
 # docs/runbooks/gitea-runner-host.md):
 #
-#   1. Linux with a running Docker Engine daemon.
-#   2. The role runs in the CI job container via connection: local
-#      (co-located with the bootstrap controller), WITHOUT privilege
-#      escalation, driving the host Docker daemon via the bind-mounted
-#      socket — no sudo on the host is required.
-#   3. The HOST is a tailnet node (kernel mode) so the runner CONTAINER
-#      can reach Gitea / tailnet at runtime. This role deploys no
-#      Tailscale sidecar and never calls the Gitea API itself (the
-#      registration token is injected — see gitea_runner_token).
+#   1. Linux with a running Docker Engine daemon (provided by
+#      runner_host_seed or the target's own IaC; this role only ASSERTS it).
+#   2. The role is applied OVER SSH to the target (gitea-deploy.yml Play 2,
+#      hosts: gitea_runner) and drives the host Docker daemon there. It is a
+#      pure consumer — it installs nothing.
+#   3. The HOST is a tailnet node (kernel mode) so the runner CONTAINER can
+#      reach Gitea at runtime. This role deploys no Tailscale sidecar and
+#      never calls the Gitea API itself (the registration token is injected
+#      — see gitea_runner_token).
 #   4. A writable data directory for runner state (default below).
 #
 # Anything host-specific (paths, OS package management, kernel quirks) is
@@ -32,15 +32,11 @@
 # value there would just drift. Do not duplicate these literals.
 
 # Where the runner keeps its registration + config + cache. This is a
-# FIXED HOST path, never a per-user ~ dir: in the co-located bootstrap
-# topology the role runs in the CI container (connection: local) and
-# writes here, while the HOST Docker daemon bind-mounts this SAME host
-# path into the runner container. The CI job bind-mounts this exact path
-# and bootstrap-runner.sh provisions it, so the bytes are coherent across
-# both. A ~ path would resolve to the CI container's filesystem, not the
-# host's (the classic bind-source-resolution bug). Override via the
-# GITEA_RUNNER_DATA_PATH CI variable; if you change it, change the CI
-# job's bind-mount in .github/workflows/common-bootstrap.yml to match.
+# FIXED HOST path on the target, never a per-user ~ dir: the role writes
+# here over SSH (as root via become) and the HOST Docker daemon bind-mounts
+# this SAME path into the runner container, so the bytes are coherent.
+# runner_host_seed creates it. Override via the GITEA_RUNNER_DATA_PATH CI
+# variable (keep runner_host_seed_data_path in sync).
 gitea_runner_data_path: >-
   {{ lookup('ansible.builtin.env', 'GITEA_RUNNER_DATA_PATH')
      | default('/opt/gitea-runner', true) }}
@@ -64,5 +60,17 @@ gitea_runner_name: >-
 
 # gitea_runner_token is REQUIRED and injected by the deploy (minted in
 # gitea-deploy.yml Play 1 on the NAS, passed via hostvars). This role does
-# NOT call the Gitea API to mint it — the CI container cannot reach the
-# Gitea API. No api-base-url / validate-certs knobs: there is no API call.
+# NOT call the Gitea API to mint it. No api-base-url / validate-certs knobs:
+# there is no API call.
+
+# Optional: Gitea's TAILNET IP, used to pin gitea_instance_url's hostname ->
+# this IP in the act_runner container's /etc/hosts. Needed when the runner
+# host joined the tailnet with MagicDNS disabled (--accept-dns=false, the
+# shared-host-safe default — see runner_host_seed_accept_dns): without
+# MagicDNS the container can't resolve gitea.<tailnet>, so we pin it. TLS
+# still validates because the connection uses the hostname (Tailscale Serve
+# cert). Empty = rely on the host's MagicDNS (dedicated-host behaviour).
+# Injected by gitea-deploy.yml Play 1 (captured from the Gitea sidecar).
+gitea_runner_gitea_tailnet_ip: >-
+  {{ lookup('ansible.builtin.env', 'GITEA_RUNNER_GITEA_TAILNET_IP')
+     | default('', true) }}

--- a/playbooks/roles/gitea_runner/tasks/main.yml
+++ b/playbooks/roles/gitea_runner/tasks/main.yml
@@ -1,16 +1,13 @@
 ---
 # Deploy a Gitea Actions runner as a single socket-mounted container.
-# Host-agnostic. Runs in the CI job container via connection: local
-# (co-located with the bootstrap controller — see
-# docs/runbooks/gitea-runner-host.md), driving the HOST Docker daemon
-# through the bind-mounted socket.
+# Host-agnostic. Applied OVER SSH to the target (gitea-deploy.yml Play 2,
+# hosts: gitea_runner) and drives the target's Docker daemon. Pure
+# consumer: it installs nothing (runner_host_seed provides Docker + tailnet).
 #
-# The runner registration token is NOT minted here. The CI container
-# cannot reach the Gitea admin API (Gitea HTTP is loopback-only on the
-# NAS; the tailnet URL is unresolvable from a non-tailnet container). It
-# is minted in gitea-deploy.yml Play 1 on the NAS (working loopback admin
-# API) and passed in via `gitea_runner_token` (hostvars) — the same
-# cross-play pattern the admin token uses.
+# The runner registration token is NOT minted here — it is minted in
+# gitea-deploy.yml Play 1 on the NAS (working loopback admin API) and passed
+# in via `gitea_runner_token` (hostvars). This role never calls the Gitea
+# API.
 
 - name: Assert the runner registration token was provided by the deploy
   assert:
@@ -43,6 +40,10 @@
   changed_when: false
   failed_when: gitea_runner_ts_status.rc != 0
 
+- name: Derive the Gitea host from the instance URL (for the optional /etc/hosts pin)
+  set_fact:
+    gitea_runner_gitea_host: "{{ gitea_instance_url | regex_replace('^https?://', '') | regex_replace('[:/].*$', '') }}"
+
 - name: Ensure Gitea runner config directory exists
   file:
     path: "{{ gitea_runner_config_file_parent }}"
@@ -61,9 +62,16 @@
 # and for jobs that ssh tailnet hosts) through the HOST's Tailscale, not a
 # sidecar — so plain bridge networking is correct here. Job containers are
 # spawned on the host's Docker daemon via the bind-mounted socket, so they
-# inherit the host's networking and DNS directly. `network_mode: bridge`
-# is explicit (never `container:<sidecar>` — see tests/check_docker_tasks.py
-# Check E and docs/runbooks/gitea-runner-host.md).
+# inherit the host's networking directly. `network_mode: bridge` is explicit
+# (never `container:<sidecar>` — see tests/check_docker_tasks.py Check E and
+# docs/runbooks/gitea-runner-host.md).
+#
+# DNS: when the host runs MagicDNS the container resolves gitea.<tailnet>
+# via the host. On a shared host joined with --accept-dns=false (the
+# safe default — see runner_host_seed_accept_dns) there is no MagicDNS, so
+# we pin gitea_instance_url's host -> Gitea's tailnet IP via etc_hosts when
+# gitea_runner_gitea_tailnet_ip is provided. TLS still validates (hostname
+# is unchanged; Tailscale Serve cert matches).
 - name: Deploy Gitea runner container (socket-mounted)
   community.docker.docker_container:
     name: gitea-runner
@@ -71,6 +79,7 @@
     state: started
     restart_policy: always
     network_mode: bridge
+    etc_hosts: "{{ {gitea_runner_gitea_host: gitea_runner_gitea_tailnet_ip} if (gitea_runner_gitea_tailnet_ip | string | length > 0) else omit }}"
     env:
       CONFIG_FILE: "/data/conf/config.yml"
       GITEA_INSTANCE_URL: "{{ gitea_instance_url }}"

--- a/playbooks/roles/runner_host_seed/defaults/main.yml
+++ b/playbooks/roles/runner_host_seed/defaults/main.yml
@@ -11,8 +11,20 @@ runner_host_seed_data_path: >-
      | default('/opt/gitea-runner', true) }}
 
 # Tailnet authkey for the host's `tailscale up`. Injected by the deploy
-# (reuses the existing TS_AUTHKEY CI secret). REQUIRED.
+# (reuses the existing TS_AUTHKEY CI secret). REQUIRED only when the host
+# is not already on the tailnet (a join is needed).
 runner_host_seed_tailscale_authkey: ""
+
+# Join the tailnet with MagicDNS DISABLED (--accept-dns=false) by default.
+# Rationale: on a SHARED host (one also running other services, e.g. a
+# sensor/telemetry bridge), accept-dns=true makes tailscaled rewrite
+# /etc/resolv.conf and the host loses resolution of its own LAN names
+# (e.g. *.iot.<lan-domain>), breaking those co-located services. With
+# accept-dns=false the host's resolver is untouched; the runner CONTAINER
+# instead reaches Gitea via an explicit /etc/hosts pin (see the gitea_runner
+# role's gitea_runner_gitea_tailnet_ip). Set true only on a DEDICATED runner
+# host whose tailnet split-DNS already covers its LAN domains.
+runner_host_seed_accept_dns: false
 
 # Docker SDK for Python version (matches the runner image). Override if
 # the runner image's pin changes.

--- a/playbooks/roles/runner_host_seed/tasks/main.yml
+++ b/playbooks/roles/runner_host_seed/tasks/main.yml
@@ -3,15 +3,6 @@
 # become. Idempotent. The gitea_runner role ASSERTS what this PROVIDES.
 # See docs/runbooks/gitea-runner-host.md.
 
-- name: Assert a tailnet authkey was provided
-  assert:
-    that:
-      - runner_host_seed_tailscale_authkey | string | length > 0
-    fail_msg: >-
-      runner_host_seed_tailscale_authkey is empty. Pass the TS_AUTHKEY CI
-      secret so this host can join the tailnet (the runner CONTAINER needs
-      tailnet egress to reach Gitea). See docs/runbooks/gitea-runner-host.md.
-
 - name: Ensure Docker Engine is installed (get.docker.com)
   ansible.builtin.shell: |
     set -eu
@@ -70,11 +61,27 @@
   changed_when: false
   failed_when: false
 
+- name: Assert a tailnet authkey was provided (only when a join is needed)
+  # Not required on a host already on the tailnet (idempotent re-runs and
+  # hosts joined out-of-band, e.g. an interactive `tailscale up`).
+  assert:
+    that:
+      - runner_host_seed_tailscale_authkey | string | length > 0
+    fail_msg: >-
+      Host is not on the tailnet and runner_host_seed_tailscale_authkey is
+      empty. Pass the TS_AUTHKEY CI secret so this host can join (the runner
+      CONTAINER needs tailnet egress to reach Gitea). See
+      docs/runbooks/gitea-runner-host.md.
+  when: ts_status.rc != 0
+
 - name: Join the tailnet (only when not already up)
-  # Kernel mode, no --ssh. Gated on status so re-runs are true no-ops and
-  # the play output reflects a real join only when one happens.
+  # Kernel mode, no --ssh. --accept-dns is DISABLED by default so tailscaled
+  # does not rewrite the host's /etc/resolv.conf (protects a shared host's
+  # own LAN name resolution — see runner_host_seed_accept_dns). Gated on
+  # status so re-runs are true no-ops and the play output reflects a real
+  # join only when one happens.
   ansible.builtin.command:
-    cmd: "tailscale up --authkey {{ runner_host_seed_tailscale_authkey }}"
+    cmd: "tailscale up --authkey {{ runner_host_seed_tailscale_authkey }} --accept-dns={{ runner_host_seed_accept_dns | string | lower }}"
   when: ts_status.rc != 0
   no_log: true
 

--- a/tests/test-regression.yml
+++ b/tests/test-regression.yml
@@ -343,6 +343,28 @@
           the gitea_runner role must ASSERT Docker (docker_host_info) and
           tailnet (tailscale status) as a pure consumer.
 
+    - name: "CHECK 8: Assert shared-host DNS safety (accept-dns off + Gitea /etc/hosts pin)"
+      # A shared runner host (one also running other services) must NOT have
+      # its /etc/resolv.conf clobbered by tailscaled. The seed joins with
+      # --accept-dns (default false); the runner then reaches Gitea via an
+      # explicit etc_hosts pin to Gitea's tailnet IP, which the deploy
+      # captures in Play 1. (Otherwise a co-located service's LAN name
+      # resolution would break.)
+      assert:
+        that:
+          - "'--accept-dns' in seed_tasks"
+          - "'runner_host_seed_accept_dns' in seed_tasks"
+          - "'etc_hosts' in runner_tasks"
+          - "'gitea_runner_gitea_tailnet_ip' in runner_tasks"
+          - "'tailscale ip -4' in gitea_deploy"
+          - "'gitea_runner_gitea_tailnet_ip' in gitea_deploy"
+        fail_msg: >
+          Shared-host DNS safety regressed: runner_host_seed must join with
+          --accept-dns (gated by runner_host_seed_accept_dns) so it does not
+          rewrite the host resolver, the gitea_runner role must pin Gitea via
+          etc_hosts/gitea_runner_gitea_tailnet_ip, and gitea-deploy.yml Play 1
+          must capture Gitea's tailnet IP (tailscale ip -4) and pass it on.
+
     - name: "CHECK 8: Assert the registration token is minted in Play 1, not the role"
       assert:
         that:


### PR DESCRIPTION
## Summary
The `gitea_runner` deploy machinery (merged in #119) had a real bug on a **shared** runner host (one also running other services): `runner_host_seed` joined Tailscale with the default `--accept-dns=true`, which makes `tailscaled` **rewrite the host's `/etc/resolv.conf`** and the host loses resolution of its own LAN names — breaking co-located services. This folds the now-running runner host into IaC and fixes that.

- **`runner_host_seed`**: join with **`--accept-dns=false`** (`runner_host_seed_accept_dns`, default `false`) so the host resolver is untouched; require the authkey **only when a join is actually needed** (idempotent on already-/interactively-joined hosts).
- **`gitea_runner`**: when MagicDNS is off, pin the Gitea hostname → its tailnet IP in the act_runner container's `/etc/hosts` (`gitea_runner_gitea_tailnet_ip`). TLS still validates (hostname unchanged). Empty ⇒ fall back to host MagicDNS (dedicated-host behaviour).
- **`gitea-deploy.yml` Play 1**: capture the Gitea sidecar's tailnet IP and thread it to Play 2 (same `hostvars` pattern as the registration token).
- **Regression CHECK 8**: lock in accept-dns + the `/etc/hosts` pin + Play 1 IP capture.
- **Docs**: runbook section on shared-host DNS; refreshed stale `connection:local`/co-located comments in the role.
- **chore**: gitignore `.claude/` (local agent state).

## Test plan
- [x] `ansible-playbook tests/test-regression.yml` → `failed=0` (incl. new CHECK 8 assertions + `check_docker_tasks.py`).
- [x] Reproduces a runner host brought up by hand (which used `--accept-dns=false` + `--add-host`), now expressed as IaC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)