### PR TITLE
fix(gitea): tolerate slow MySQL recovery on unclean restart (no crash-loop)

### DIFF
--- a/playbooks/roles/gitea_server/tasks/main.yml
+++ b/playbooks/roles/gitea_server/tasks/main.yml
@@ -171,7 +171,13 @@
       interval: 30s
       timeout: 8s
       retries: 3
-      start_period: 2m
+      # 10m (not 2m): after an unclean restart Docker relaunches gitea and
+      # gitea-db independently (no depends_on:service_healthy at restart
+      # time), so gitea is up but cannot serve HTTP until MySQL finishes
+      # InnoDB crash recovery. A 2m start_period marks gitea unhealthy
+      # mid-recovery (tripping monitors / the sidecar self-heal). Matches
+      # the gitea-db start_period and gitea's DB_RETRIES budget (app.ini).
+      start_period: 10m
   when: tailscale_enabled | default(false) | bool
   tags: gitea
   notify: Restart Gitea
@@ -202,7 +208,13 @@
       interval: 30s
       timeout: 8s
       retries: 3
-      start_period: 2m
+      # 10m (not 2m): after an unclean restart Docker relaunches gitea and
+      # gitea-db independently (no depends_on:service_healthy at restart
+      # time), so gitea is up but cannot serve HTTP until MySQL finishes
+      # InnoDB crash recovery. A 2m start_period marks gitea unhealthy
+      # mid-recovery (tripping monitors / the sidecar self-heal). Matches
+      # the gitea-db start_period and gitea's DB_RETRIES budget (app.ini).
+      start_period: 10m
   when: not (tailscale_enabled | default(false) | bool)
   tags: gitea
   notify: Restart Gitea

--- a/playbooks/templates/app.ini.j2
+++ b/playbooks/templates/app.ini.j2
@@ -22,6 +22,19 @@ HOST = gitea-db:3306
 NAME = {{ gitea_db_name }}
 USER = {{ gitea_db_user }}
 PASSWD = {{ gitea_db_password }}
+; On an unclean restart (HyperBackup quiesce, a ContainerManager bounce,
+; a host reboot) Docker's restart_policy=always relaunches gitea and
+; gitea-db INDEPENDENTLY — there is no depends_on:service_healthy at
+; restart time (the deploy-time "Wait for gitea-db healthy" gate only runs
+; during an Ansible deploy). MySQL then needs minutes for InnoDB crash
+; recovery while gitea is already up and trying to connect. Gitea's
+; defaults (DB_RETRIES=10 x DB_RETRY_BACKOFF=3s ~= 30s) are far too short:
+; gitea exhausts them, exits, and restart:always crash-loops it for the
+; whole recovery window. 60 x 10s = 600s matches the gitea-db container's
+; healthcheck start_period (10m) and the deploy-time wait gate, so gitea
+; waits out recovery instead of flapping.
+DB_RETRIES = {{ gitea_db_retries | default(60) }}
+DB_RETRY_BACKOFF = {{ gitea_db_retry_backoff | default('10s') }}
 
 [security]
 INSTALL_LOCK = true

--- a/tests/test-regression.yml
+++ b/tests/test-regression.yml
@@ -125,6 +125,21 @@
           - "'SSH_DOMAIN = gitea.test-tailnet.ts.net' in ini_content"
         fail_msg: "app.ini SSH_DOMAIN should use the tailnet domain"
 
+    - name: "CHECK 3: Assert app.ini widens the DB connect retry budget"
+      # Gitea's defaults (DB_RETRIES=10 x DB_RETRY_BACKOFF=3s ~= 30s) are too
+      # short to outlast MySQL's InnoDB crash recovery after an unclean
+      # restart, so gitea exits and restart:always crash-loops it. The
+      # template must widen this to ~10m (60 x 10s) to match the gitea-db
+      # healthcheck start_period and the deploy-time wait gate.
+      assert:
+        that:
+          - "'DB_RETRIES = 60' in ini_content"
+          - "'DB_RETRY_BACKOFF = 10s' in ini_content"
+        fail_msg: >
+          app.ini must set DB_RETRIES=60 and DB_RETRY_BACKOFF=10s (~10m of
+          retries) so gitea waits out MySQL InnoDB crash recovery instead of
+          crash-looping after an unclean restart. Got: {{ ini_content }}
+
     # ================================================================
     # Check 4: ts-serve-gitea.json.j2 renders correctly (Gap 5)
     # ================================================================
@@ -621,6 +636,42 @@
           never 'sed -i'). Without a continuous reconciler the deploy-time fix is
           stripped on the next tailscaled restart and gitea loses gitea-db
           resolution (2026-06-05 incident).
+
+    # ================================================================
+    # Check 16: gitea container healthcheck tolerates slow DB recovery
+    # ================================================================
+    # After an unclean restart, Docker's restart_policy=always relaunches
+    # gitea and gitea-db independently (there is no depends_on:service_healthy
+    # at restart time — that gate only runs during an Ansible deploy). MySQL
+    # needs minutes for InnoDB crash recovery; gitea is up but cannot serve
+    # HTTP until the DB is reachable. With a 2m healthcheck start_period gitea
+    # is marked unhealthy mid-recovery, tripping external monitors / the
+    # sidecar self-heal. The start_period must match the gitea-db recovery
+    # budget (10m) on BOTH the Tailscale and standalone container variants,
+    # paired with the widened DB_RETRIES/DB_RETRY_BACKOFF in app.ini (CHECK 3).
+    - name: "CHECK 16: Read gitea_server tasks/main.yml"
+      slurp:
+        src: "{{ roles_dir }}/gitea_server/tasks/main.yml"
+      register: gitea_server_tasks_raw
+
+    - name: "CHECK 16: Decode gitea_server tasks"
+      set_fact:
+        gitea_server_tasks: "{{ gitea_server_tasks_raw.content | b64decode }}"
+
+    - name: "CHECK 16: Assert gitea healthcheck start_period tolerates DB recovery (10m, both variants)"
+      assert:
+        that:
+          # gitea-db (1) + gitea Tailscale variant (1) + gitea standalone
+          # variant (1) = 3 occurrences once the 2m budgets are raised.
+          - "gitea_server_tasks.count('start_period: 10m') >= 3"
+          - "'start_period: 2m' not in gitea_server_tasks"
+        fail_msg: >
+          gitea_server/tasks/main.yml must use start_period: 10m for the gitea
+          container healthcheck on BOTH the Tailscale and standalone variants
+          (alongside the gitea-db healthcheck) so gitea is not marked unhealthy
+          while MySQL does InnoDB crash recovery after an unclean restart. The
+          old 2m budget is banned. Pairs with the widened DB retry budget in
+          app.ini (CHECK 3).
 
     # ================================================================
     # Cleanup


### PR DESCRIPTION
## Problem (Fix 1 of 4 — NAS gitea instability)

Gitea on the NAS crash-loops after an **unclean** stop of the stack (a HyperBackup quiesce around 04:03, a Container Manager bounce, or a host reboot).

**Root cause:** at restart time Docker's `restart_policy: always` brings `gitea` and `gitea-db` back up **independently**. There is **no** `depends_on: service_healthy` at restart time — the only such gate (`Wait for gitea-db to be healthy`, `gitea_server/tasks/main.yml`) runs **only during an Ansible deploy**. MySQL then spends minutes on InnoDB crash recovery while `gitea` is already up and trying to connect. Gitea's default DB-connect budget is `DB_RETRIES=10 × DB_RETRY_BACKOFF=3s ≈ 30s` — exhausted long before MySQL is ready (observed log: `ORM engine initialization attempt #N/10`). Gitea exits, `restart: always` relaunches it, and it flaps for the whole recovery window.

This is the failure mode left *after* the resolv.conf self-heal (#115/#116/#118) — even with `gitea-db` name resolution working, gitea still gives up on the *connection* too early.

## Fix

The only retry budget Docker honors at restart time is gitea's own, so the fix lives in `app.ini`:

- **`app.ini`** — `DB_RETRIES = 60`, `DB_RETRY_BACKOFF = 10s` (≈ 10m), matching the `gitea-db` healthcheck `start_period` (10m) and the deploy-time wait gate. Gitea now waits out InnoDB recovery instead of crash-looping. Both overridable via `gitea_db_retries` / `gitea_db_retry_backoff`.
- **`gitea_server/tasks/main.yml`** — gitea container healthcheck `start_period` `2m → 10m` on **both** the Tailscale and standalone variants, so gitea isn't flagged unhealthy mid-recovery (which would trip external monitors / the sidecar self-heal).

## Tests

`cd playbooks && ansible-playbook ../tests/test-regression.yml` → `ok=67, failed=0`.

- **CHECK 3** extended: asserts the widened budget renders (`DB_RETRIES = 60`, `DB_RETRY_BACKOFF = 10s`).
- **CHECK 16** (new): locks `start_period: 10m` on both gitea container variants and bans the old `2m`.

## Scope

This is the **durable IaC fix** (Fix 1 of 4). The other three (HyperBackup quiesce trigger, NAS memory pressure, Container Manager wedged state) are operator/root-side and tracked separately. The Container Manager repair (which bounces all containers) should be done **after** this merges/deploys so gitea doesn't re-flap during recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)