### PR TITLE
fix(gitea): pin json-file log driver to escape Synology db-driver wedge

### DIFF
--- a/playbooks/roles/gitea_server/tasks/main.yml
+++ b/playbooks/roles/gitea_server/tasks/main.yml
@@ -45,6 +45,18 @@
     image: "{{ gitea_db_image }}"
     state: started
     restart_policy: always
+    # Pin json-file logging. The Synology default `db` log driver wedges
+    # (locks/hangs): a wedged driver makes Docker unable to run healthcheck
+    # execs (container flips unhealthy) AND unable to (re)start a container
+    # ("failed to initialize logging driver"), so autoheal's restart leaves
+    # it dead. json-file is local-file logging with rotation, immune to that
+    # wedge. Explicit per-container (not just the daemon default) so it
+    # survives a ContainerManager update resetting the default back to `db`.
+    # (2026-06-15 incident; see also 2026-06-05.)
+    log_driver: json-file
+    log_options:
+      max-size: "10m"
+      max-file: "3"
     memory: "384m"
     memory_swap: "768m"
     networks:
@@ -158,6 +170,12 @@
     image: "{{ gitea_image }}"
     state: started
     restart_policy: always
+    # Pin json-file logging — avoid the Synology `db` log-driver wedge that
+    # breaks healthchecks + restarts. (2026-06-15 incident.)
+    log_driver: json-file
+    log_options:
+      max-size: "10m"
+      max-file: "3"
     network_mode: "container:{{ tailscale_gitea_container_name }}"
     env:
       USER_UID: "1000"
@@ -188,6 +206,12 @@
     image: "{{ gitea_image }}"
     state: started
     restart_policy: always
+    # Pin json-file logging — avoid the Synology `db` log-driver wedge that
+    # breaks healthchecks + restarts. (2026-06-15 incident.)
+    log_driver: json-file
+    log_options:
+      max-size: "10m"
+      max-file: "3"
     memory: "256m"
     memory_swap: "512m"
     networks:

--- a/playbooks/roles/tailscale_sidecar/tasks/main.yml
+++ b/playbooks/roles/tailscale_sidecar/tasks/main.yml
@@ -33,6 +33,12 @@
     image: "{{ tailscale_image }}"
     state: started
     restart_policy: always
+    # Pin json-file logging — avoid the Synology `db` log-driver wedge that
+    # breaks healthchecks + restarts. (2026-06-15 incident.)
+    log_driver: json-file
+    log_options:
+      max-size: "10m"
+      max-file: "3"
     networks:
       - name: "{{ tailscale_network_name }}"
     ports: "{{ tailscale_host_ports | default([], true) }}"

--- a/tests/test-regression.yml
+++ b/tests/test-regression.yml
@@ -696,6 +696,35 @@
           app.ini (CHECK 3).
 
     # ================================================================
+    # Check 17: Gitea-stack containers pin the json-file log driver,
+    #           never the Synology `db` driver.
+    # ================================================================
+    # The Synology ContainerManager default `db` log driver wedges
+    # (locks/hangs). A wedged driver makes Docker unable to run healthcheck
+    # execs (container flips unhealthy) and unable to (re)start containers
+    # ("failed to initialize logging driver"), so autoheal's restart leaves
+    # them dead — a recurring NAS-wide outage (2026-06-15 incident; also
+    # 2026-06-05). Every long-lived gitea-stack container must pin
+    # log_driver: json-file explicitly (not merely rely on the daemon
+    # default, which a ContainerManager update can reset back to `db`).
+    # Reuses gitea_server_tasks (decoded in CHECK 16) and tailscale_sidecar_tasks.
+    - name: "CHECK 17: Assert gitea + sidecar containers pin json-file logging"
+      assert:
+        that:
+          # gitea-db, gitea (sidecar variant), gitea (standalone variant) =
+          # 3 occurrences in gitea_server; allow >=3 for future containers.
+          - "gitea_server_tasks.split('log_driver: json-file') | length - 1 >= 3"
+          - "'log_driver: json-file' in tailscale_sidecar_tasks"
+          # Guard the anti-pattern: no container may pin the wedge-prone db driver.
+          - "'log_driver: db' not in gitea_server_tasks"
+          - "'log_driver: db' not in tailscale_sidecar_tasks"
+        fail_msg: >
+          Every long-lived gitea-stack container (gitea-db, gitea, the
+          tailscale-gitea sidecar) must set 'log_driver: json-file'. The
+          Synology default 'db' log driver wedges and breaks healthchecks +
+          restarts, taking the whole stack down (2026-06-15 incident).
+
+    # ================================================================
     # Cleanup
     # ================================================================
     - name: Clean up rendered test files


### PR DESCRIPTION
## Root cause (confirmed live, 2026-06-15)

The Synology ContainerManager default **`db` log driver wedges** (locks/hangs). A wedged driver compounds:
1. Docker can't run healthcheck execs → container flips `unhealthy` (`timed out starting health check` in the health log).
2. Docker can't (re)start a container (`failed to initialize logging driver`).

With **autoheal** (`AUTOHEAL_CONTAINER_LABEL=all`) watching every healthchecked container, (1) triggers a `docker restart` and (2) makes that restart **fail** — leaving `gitea`/`openbao`/`authentik` dead (`Exited 128`) until manually started.

Evidence — autoheal log shows it recurring:
```
14-06 05:01:58  gitea  unhealthy → Restarting container failed
15-06 04:12:22  gitea  unhealthy → Restarting container failed
```
And `docker logs gitea` hung (exit 124) on the `db` driver. Same class as the 2026-06-05 "database is locked" log-driver incident.

## Fix

Pin **`log_driver: json-file`** (+ 10m/3-file rotation) on every long-lived gitea-stack container (`gitea`, `gitea-db`, `tailscale-gitea`). json-file is local-file logging, immune to the db-driver wedge.

Pinned **explicitly per container**, not merely via the daemon default — a ContainerManager update can reset the daemon default back to `db`, so the IaC must re-assert it every deploy (defense in depth).

Also applied at the daemon level on the NAS (`dockerd.json` default → `json-file`) so newly-created containers are safe too.

## Test
- Adds regression **CHECK 16**: asserts the stack pins `json-file` and bans `log_driver: db`.
- Local: full regression suite green (`failed=0`).

## Deployed
Recreated the gitea stack via `gitea-deploy.yml --limit nas`; verified all three containers now `json-file`, `docker logs` no longer hangs, gitea `healthy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)