### PR TITLE
Install plugins via SessionStart hook (debuggable) instead of cloud setup script

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,5 +9,18 @@
   },
   "enabledPlugins": {
     "superpowers@superpowers-marketplace": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/install-plugins.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/scripts/install-plugins.sh
+++ b/scripts/install-plugins.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -uo pipefail
+
+# === Install Claude Code plugins declared in .claude/settings.json ===
+#
+# Wired as a SessionStart hook so its output is visible in the session — unlike
+# the cloud environment "Setup script", whose output you can't see. Reads
+# `extraKnownMarketplaces` + `enabledPlugins` from .claude/settings.json and
+# installs them via the `claude` CLI. Idempotent: safe to run every session.
+#
+# Intentionally verbose for debuggability. It never exits non-zero (a failing
+# SessionStart hook shouldn't block the session) — it reports problems instead.
+# Once it's working you can quiet it down.
+
+log() { echo "[install-plugins] $*"; }
+
+log "start: CLAUDE_CODE_REMOTE=${CLAUDE_CODE_REMOTE:-<unset>} user=$(id -un 2>/dev/null) pwd=$(pwd)"
+
+# === Only run in cloud (Claude Code on the web) sessions ===
+# Delete this guard to also run in local sessions.
+if [[ "${CLAUDE_CODE_REMOTE:-}" != "true" ]]; then
+  log "not a cloud session (CLAUDE_CODE_REMOTE != true) — skipping."
+  exit 0
+fi
+
+# === Locate settings.json ===
+SETTINGS="${CLAUDE_PROJECT_DIR:-.}/.claude/settings.json"
+[[ -f "$SETTINGS" ]] || SETTINGS=".claude/settings.json"
+if [[ ! -f "$SETTINGS" ]]; then
+  log "ERROR: no .claude/settings.json (CLAUDE_PROJECT_DIR=${CLAUDE_PROJECT_DIR:-<unset>}, cwd=$(pwd)) — nothing to do."
+  exit 0
+fi
+log "using settings: $SETTINGS"
+
+# === Required tools ===
+for bin in claude jq; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    log "ERROR: required tool '$bin' not found on PATH."
+    log "  PATH=$PATH"
+    exit 0
+  fi
+done
+log "claude: $(command -v claude) ($(claude --version 2>/dev/null | head -1))"
+
+# === Register each declared marketplace ===
+# github sources -> "owner/repo"; url/git -> URL; local -> path.
+mapfile -t MARKETS < <(jq -r '
+  (.extraKnownMarketplaces // {}) | to_entries[] | .value.source |
+  if .source == "github" then .repo
+  elif (.url  // empty) then .url
+  elif (.path // empty) then .path
+  else empty end
+' "$SETTINGS")
+
+for m in "${MARKETS[@]}"; do
+  [[ -n "$m" ]] || continue
+  log "marketplace add: $m"
+  claude plugin marketplace add "$m" 2>&1 | sed 's/^/[install-plugins]   /'
+  rc=${PIPESTATUS[0]}
+  [[ $rc -eq 0 ]] && log "  marketplace add OK" || log "  marketplace add FAILED (exit $rc)"
+done
+
+# === Install each enabled plugin ("plugin@marketplace": true) ===
+mapfile -t PLUGINS < <(jq -r '(.enabledPlugins // {}) | to_entries[] | select(.value==true) | .key' "$SETTINGS")
+
+for p in "${PLUGINS[@]}"; do
+  [[ -n "$p" ]] || continue
+  log "install: $p"
+  claude plugin install "$p" 2>&1 | sed 's/^/[install-plugins]   /'
+  rc=${PIPESTATUS[0]}
+  [[ $rc -eq 0 ]] && log "  install OK" || log "  install FAILED (exit $rc)"
+done
+
+log "done. currently installed:"
+claude plugin list 2>&1 | sed 's/^/[install-plugins]   /' || true
+exit 0


### PR DESCRIPTION
## What

Move plugin installation from the cloud environment **Setup script** to an in-repo **SessionStart hook**, so its output is visible in the session and failures can actually be diagnosed.

## Why

The cloud environment "Setup script" runs opaquely — there's no visibility into its output, so when the plugin install fails there's no way to see why. A `SessionStart` hook runs inside the session, so its output shows up where you can read it.

## Changes

- **`scripts/install-plugins.sh`** (new, `+x`) — data-driven installer:
  - Reads `extraKnownMarketplaces` + `enabledPlugins` from `.claude/settings.json` (so it works for any plugin you declare, not just superpowers)
  - Cloud-gated (`CLAUDE_CODE_REMOTE=true`); no-ops in local sessions
  - Idempotent; **never exits non-zero** so it can't block session startup
  - Intentionally verbose: logs env context, the `claude` path/version, and a pass/fail line with exit code for each marketplace-add and plugin-install, then prints `claude plugin list`
- **`.claude/settings.json`** — adds the `SessionStart` hook (`startup|resume`) that runs the script. The declarative `extraKnownMarketplaces`/`enabledPlugins` stay as-is.

## Validation

Ran the script in this cloud session (`CLAUDE_CODE_REMOTE=true`). Sample output:

```
[install-plugins] start: CLAUDE_CODE_REMOTE=true user=root pwd=/home/user/jaxzin-infra-bootstrap
[install-plugins] using settings: .../.claude/settings.json
[install-plugins] claude: /opt/node22/bin/claude (2.1.179 (Claude Code))
[install-plugins] marketplace add: obra/superpowers-marketplace
[install-plugins]   √ Marketplace 'superpowers-marketplace' already on disk
[install-plugins]   marketplace add OK
[install-plugins] install: superpowers@superpowers-marketplace
[install-plugins]   √ Plugin "superpowers@superpowers-marketplace" is already installed (scope: user)
[install-plugins]   install OK
[install-plugins] done. currently installed:
[install-plugins]     > superpowers@superpowers-marketplace  Version: 6.0.2  Status: √ enabled
```

`bash -n` clean; `.claude/settings.json` is valid JSON.

## Note
This re-adds the hook + script that the prior PR (#129) intentionally dropped in favor of declarative-only config — added back here because the cloud Setup-script path isn't working and isn't debuggable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ajwSARfXUogcs9GjCGjuA

---
_Generated by [Claude Code](https://claude.ai/code/session_018ajwSARfXUogcs9GjCGjuA)_