### PR TITLE
fix(gitea_runner): seed passwordless sudo so Play 2 SSH deploy can become

### DIFF
--- a/docs/runbooks/gitea-runner-host.md
+++ b/docs/runbooks/gitea-runner-host.md
@@ -14,7 +14,11 @@ runner target are **different machines**, connected over SSH.
 ## Target-host contract (the only things assumed)
 
 1. Reachable over **SSH** from the controller, with a sudo-capable user
-   (`GITEA_RUNNER_SSH_USER`) and the `GITEA_RUNNER_SSH_KEY` authorized.
+   (`GITEA_RUNNER_SSH_USER`) and the `GITEA_RUNNER_SSH_KEY` authorized. Play 2
+   runs `become: true` with key auth and **no** become password, so that user
+   needs **passwordless sudo** — the one-time seed below installs it (a
+   `/etc/sudoers.d/gitea-runner` NOPASSWD drop-in). Without it Play 2 fails on
+   its first escalation with `Missing sudo password`.
 2. Reachable **before** it is on the tailnet (the seed joins the tailnet),
    so `GITEA_RUNNER_HOST` must be LAN-resolvable at seed time.
 3. A systemd Linux host where Docker can be installed.
@@ -51,15 +55,21 @@ Set `runner_host_seed_accept_dns: true` only on a **dedicated** runner host
 whose tailnet split-DNS already covers its LAN domains (then the pin is
 unnecessary, though harmless).
 
-## SSH access (one-time seed, IaC)
+## SSH access + passwordless sudo (one-time seed, IaC)
 
 The runner deploy logs in as a sudo-capable account (`GITEA_RUNNER_SSH_USER`).
-Authorize a dedicated runner keypair once (and on DR):
+The seed authorizes a dedicated runner keypair **and** grants that account
+passwordless sudo (the NOPASSWD drop-in Play 2 needs). Run once (and on DR):
 
     ssh-keygen -t ed25519 -f gitea-runner -C gitea-runner -N ''
     # gitea-runner.pub  -> commit to playbooks/files/gitea-runner.pub
     # gitea-runner (private) -> paste into the GITEA_RUNNER_SSH_KEY CI secret
-    ansible-playbook seed-runner-ssh.yml -i 'GITEA_RUNNER_HOST,' -u <GITEA_RUNNER_SSH_USER>
+    ansible-playbook seed-runner-ssh.yml -i 'GITEA_RUNNER_HOST,' -u <GITEA_RUNNER_SSH_USER> -K
+
+On the **first** run pass `-K` (`--ask-become-pass`): passwordless sudo isn't
+in place yet, so the sudoers task needs the account's sudo password once. The
+drop-in is written with `visudo` validation, so a malformed entry can never
+land and lock sudo out. Later runs are true no-ops and need no `-K`.
 
 `seed-runner-ssh.yml` is idempotent — re-run any time / on DR. Install it
 using whatever existing SSH access you already have to the host (you cannot
@@ -70,7 +80,7 @@ install the key over the key it installs).
 | Name | Kind | Purpose |
 |---|---|---|
 | `GITEA_RUNNER_HOST` | Secret | The target host (LAN-resolvable for pre-tailnet seeding). |
-| `GITEA_RUNNER_SSH_USER` | Variable | Sudo-capable SSH user on the target. |
+| `GITEA_RUNNER_SSH_USER` | Variable | Sudo-capable SSH user on the target (the seed grants it passwordless sudo). |
 | `GITEA_RUNNER_SSH_KEY` | Secret | Private key authorized on the target. |
 | `TS_AUTHKEY` | Secret | Reused to join the target to the tailnet. |
 | `GITEA_RUNNER_IMAGE` / `_NAME` / `_DATA_PATH` | Variable | Optional overrides (see role defaults). |
@@ -104,3 +114,10 @@ The act_runner is **socket-mounted**: every CI job container has
 root-equivalent authority over the target's Docker daemon (the deliberate
 price of deleting dind). When the runner shares a host with another service,
 treat the box as single-tenant-trusted; keep runner `capacity: 1`.
+
+The deploy account also has **passwordless sudo** (`NOPASSWD: ALL`, seeded
+above). Accept knowingly: on a socket-mounted host the runner already holds
+root-equivalent authority via the Docker socket, so NOPASSWD grants nothing it
+couldn't already obtain — it just lets the unattended SSH deploy escalate
+without a stored sudo password. The grant is scoped to the dedicated deploy
+account, which is reachable only with the `GITEA_RUNNER_SSH_KEY` private key.

--- a/playbooks/seed-runner-ssh.yml
+++ b/playbooks/seed-runner-ssh.yml
@@ -1,9 +1,14 @@
 ---
 # Idempotent SSH-access seed for the Gitea runner host.
 #
-# Authorizes the DEDICATED runner public key (playbooks/files/gitea-runner.pub)
-# for the deploy account on the target, so the bootstrap CI can SSH in as
-# GITEA_RUNNER_SSH_USER with the GITEA_RUNNER_SSH_KEY private key.
+# Establishes the TWO things gitea-deploy.yml Play 2 needs on the target:
+#   1. The DEDICATED runner public key (playbooks/files/gitea-runner.pub) is
+#      authorized for the deploy account, so the bootstrap CI can SSH in as
+#      GITEA_RUNNER_SSH_USER with the GITEA_RUNNER_SSH_KEY private key.
+#   2. That account has PASSWORDLESS sudo (a /etc/sudoers.d/gitea-runner
+#      NOPASSWD drop-in). Play 2 runs `become: true` over SSH with key auth
+#      and NO become password — without this it dies on its first escalation
+#      (incl. the implicit gather_facts setup) with "Missing sudo password".
 #
 # The authorized account MUST match GITEA_RUNNER_SSH_USER. By default this
 # playbook reads that same env var (falling back to `pi`) so the seeded
@@ -12,8 +17,11 @@
 #
 # Run ONCE by the operator (and on DR) from a machine that already has SSH
 # access to the host — you cannot install the key over the key it installs.
+# On the FIRST run, passwordless sudo isn't in place yet, so pass -K (you
+# will be prompted once for the account's sudo password); later runs are
+# true no-ops and need no -K.
 #   GITEA_RUNNER_SSH_USER=pi ansible-playbook seed-runner-ssh.yml \
-#     -i 'GITEA_RUNNER_HOST,' -u "$GITEA_RUNNER_SSH_USER"
+#     -i 'GITEA_RUNNER_HOST,' -u "$GITEA_RUNNER_SSH_USER" -K
 #
 # The private key lives ONLY in the GITEA_RUNNER_SSH_KEY CI secret. The
 # public key is safe to commit. See docs/runbooks/gitea-runner-host.md.
@@ -24,7 +32,30 @@
     runner_ssh_login_user: "{{ lookup('ansible.builtin.env', 'GITEA_RUNNER_SSH_USER') | default('pi', true) }}"
   tasks:
     - name: Authorize the dedicated runner public key
+      # Writes to the deploy account's own ~/.ssh — no root needed, so this
+      # task deliberately runs WITHOUT become and still works on a host where
+      # sudo isn't usable yet (this seed is what makes sudo usable).
       ansible.posix.authorized_key:
         user: "{{ runner_ssh_login_user }}"
         state: present
         key: "{{ lookup('ansible.builtin.file', 'files/gitea-runner.pub') }}"
+
+    - name: Grant the runner deploy account passwordless sudo (NOPASSWD drop-in)
+      # NOPASSWD: ALL — Play 2 runs the whole play under `become: true` and its
+      # seed tasks legitimately need arbitrary root (get.docker.com | sh,
+      # systemctl, package/pip installs, tailscale up), so scoping to specific
+      # commands would be fiction. The box is already single-tenant-trusted and
+      # socket-mounted (root-equivalent Docker), so this adds ~no blast radius —
+      # see the security trade-off in docs/runbooks/gitea-runner-host.md.
+      #
+      # `validate: visudo -cf` syntax-checks the drop-in on a TEMP file before
+      # it is moved into place, so a malformed entry can never lock sudo out.
+      # ansible.builtin only — no extra Galaxy collection to install on DR.
+      ansible.builtin.copy:
+        dest: /etc/sudoers.d/gitea-runner
+        content: "{{ runner_ssh_login_user }} ALL=(ALL) NOPASSWD: ALL\n"
+        owner: root
+        group: root
+        mode: "0440"
+        validate: "visudo -cf %s"
+      become: true

--- a/tests/check_docker_tasks.py
+++ b/tests/check_docker_tasks.py
@@ -19,6 +19,11 @@ Checks:
   J) runner image Dockerfile must pip-install the Docker SDK (`docker`):
      gitea-deploy.yml Play 2 runs community.docker locally in this image
      (connection: local, co-located with the Gitea runner)
+  K) seed-runner-ssh.yml must grant the runner deploy account PASSWORDLESS
+     sudo: gitea-deploy.yml Play 2 runs `become: true` over SSH with key auth
+     and no become password, so a missing NOPASSWD grant makes Play 2 die on
+     its first escalation with "Missing sudo password" (regression lock-in —
+     see docs/runbooks/gitea-runner-host.md).
 
 Uses only Python stdlib — no PyYAML required.
 """
@@ -54,6 +59,20 @@ GITEA_RUNNER_FORBIDDEN_MARKERS = (
     "synology_dsm",             # DSM-only runner label
     "DOCKER_INSECURE_NO_IPTABLES_RAW",  # DSM dind workaround
 )
+
+RUNNER_SSH_SEED_PLAYBOOK = "playbooks/seed-runner-ssh.yml"
+# gitea-deploy.yml Play 2 runs `become: true` over SSH with key auth and NO
+# become password, so seed-runner-ssh.yml MUST grant the deploy account
+# passwordless sudo — otherwise Play 2 dies on its first escalation (incl. the
+# implicit gather_facts setup) with "Missing sudo password". The markers are
+# matched against NON-comment lines only (so the explanatory comments can't
+# satisfy the check on their own):
+#  - "sudoers"  → an actual sudoers grant is installed (the /etc/sudoers.d
+#                 drop-in path, or a community.general.sudoers module switch)
+#  - passwordless directive → "NOPASSWD" (drop-in literal) or "nopassword"
+#                 (the module param), so the grant is genuinely password-free
+RUNNER_SSH_SEED_SUDOERS_MARKER = "sudoers"
+RUNNER_SSH_SEED_NOPASSWD_MARKERS = ("NOPASSWD", "nopassword")
 
 GITEA_HOST_PORTS_REQUIRED = [
     re.compile(r'^["\']?127\.0\.0\.1:.*:3000["\']?$'),
@@ -386,6 +405,50 @@ def check_h_gitea_runner_socket_mount(errors):
                 )
 
 
+def check_k_runner_seed_passwordless_sudo(errors):
+    """Check K: seed-runner-ssh.yml must grant the runner deploy account
+    passwordless sudo (a NOPASSWD sudoers drop-in).
+
+    gitea-deploy.yml Play 2 (`hosts: gitea_runner`, `become: true`) connects
+    over SSH with key auth and supplies NO ansible_become_password. Without a
+    passwordless-sudo grant on the target, the very first escalation — the
+    implicit gather_facts setup — fails with "Missing sudo password" and the
+    whole runner deploy never starts (ok=0 failed=1). The one-time seed is the
+    IaC that establishes the grant; lock it in so a refactor can't silently
+    drop it and reintroduce the break. See docs/runbooks/gitea-runner-host.md.
+
+    Markers are matched against NON-comment lines only, so the explanatory
+    comments in the playbook cannot satisfy the check on their own.
+    """
+    try:
+        with open(RUNNER_SSH_SEED_PLAYBOOK) as fh:
+            lines = fh.readlines()
+    except FileNotFoundError:
+        errors.append(
+            f"{RUNNER_SSH_SEED_PLAYBOOK}: File not found; this seed is what "
+            f"grants the runner account passwordless sudo for gitea-deploy.yml "
+            f"Play 2. See docs/runbooks/gitea-runner-host.md."
+        )
+        return
+
+    code = "\n".join(ln for ln in lines if not ln.lstrip().startswith("#"))
+
+    if RUNNER_SSH_SEED_SUDOERS_MARKER not in code:
+        errors.append(
+            f"{RUNNER_SSH_SEED_PLAYBOOK}: no sudoers grant found; the seed must "
+            f"install a passwordless-sudo drop-in for the runner deploy account "
+            f"or gitea-deploy.yml Play 2 fails with 'Missing sudo password'. "
+            f"See docs/runbooks/gitea-runner-host.md."
+        )
+    elif not any(m in code for m in RUNNER_SSH_SEED_NOPASSWD_MARKERS):
+        errors.append(
+            f"{RUNNER_SSH_SEED_PLAYBOOK}: sudoers grant present but not "
+            f"passwordless (expected one of {RUNNER_SSH_SEED_NOPASSWD_MARKERS}); "
+            f"Play 2 supplies no become password, so the grant must be NOPASSWD. "
+            f"See docs/runbooks/gitea-runner-host.md."
+        )
+
+
 def main():
     errors = []
     warnings = []
@@ -416,6 +479,10 @@ def main():
     # Run check J: runner image must pip-install the Docker SDK (Play 2
     # runs community.docker locally in this image)
     check_j_dockerfile_docker_sdk(errors)
+
+    # Run check K: the runner SSH seed must grant passwordless sudo so Play 2's
+    # `become: true` deploy doesn't fail with "Missing sudo password"
+    check_k_runner_seed_passwordless_sudo(errors)
 
     # Report results
     for w in warnings:


### PR DESCRIPTION
## Problem

The `Bootstrap` deploy's **Play 2** (`gitea-deploy.yml`, `hosts: gitea_runner`, `become: true`) deploys the Gitea Actions runner over SSH to `GITEA_RUNNER_HOST`. It failed with:

```
fatal: FAILED! {"msg": "Missing sudo password"}   # ok=0 failed=1
```

**Root cause:** Play 2 connects with **key auth** and supplies **no `ansible_become_password`**, and the target's deploy account did not have passwordless sudo. SSH-login auth and sudo auth are separate gates — the inventory satisfied only the login. So the *first* escalation (the implicit `gather_facts` setup task, which runs under play-level `become`) hit a sudo password prompt Ansible couldn't answer, dying before any task ran. Play 1 (NAS) survives only because its inventory line carries `ansible_become_password`.

## Fix

Establish the missing sudo gate as **IaC in the one-time seed** rather than storing a sudo-password secret in CI:

- **`playbooks/seed-runner-ssh.yml`** — installs a `visudo`-validated `/etc/sudoers.d/gitea-runner` NOPASSWD drop-in for the deploy account. `ansible.builtin` only (no new Galaxy collection); `become` is scoped to that single task so key authorization still works on a host where sudo isn't usable yet. First run needs `-K`; later runs are no-ops.
- **`docs/runbooks/gitea-runner-host.md`** — host contract tightened "sudo-capable" → "**passwordless sudo** (granted by the seed)", documents the one-time `-K`, and records the NOPASSWD security acceptance (the socket-mounted box is already root-equivalent, so this adds ~no blast radius).
- **`tests/check_docker_tasks.py`** — new **Check K** locks the seed-grants-NOPASSWD invariant against silent regression.

## Verification

- `ansible-playbook tests/test-regression.yml` → `ok=63 failed=0`
- Negative test: Check K **fails** if the NOPASSWD grant is removed (proves the lock locks)
- `ansible-playbook --syntax-check` on the seed → clean

## Operator step (required for the live deploy to go green)

This repo change can't reach into the host. Run the seed **once** on `GITEA_RUNNER_HOST` (confirm it's the box you intend to grant passwordless root to):

```
GITEA_RUNNER_SSH_USER=<user> ansible-playbook playbooks/seed-runner-ssh.yml \
  -i 'GITEA_RUNNER_HOST,' -u "$GITEA_RUNNER_SSH_USER" -K
```

`-K` is needed only the first time (passwordless sudo isn't in place yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)