### PR TITLE
Harden #132: vendor jaxzin.infra for DR + un-cap tailscale memory + restore #7 watchdog test locks

### DIFF
--- a/playbooks/collections/ansible_collections/jaxzin/infra/CHANGELOG.md
+++ b/playbooks/collections/ansible_collections/jaxzin/infra/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+# [1.6.0](https://github.com/jaxzin/ansible-collection-infra/compare/1.5.0...1.6.0) (2026-06-17)
+
+
+### Features
+
+* **tailscale_sidecar:** add opt-in userspace networking mode ([#10](https://github.com/jaxzin/ansible-collection-infra/issues/10)) ([d361f54](https://github.com/jaxzin/ansible-collection-infra/commit/d361f54898e418f416411b8d9b7f946f6a7a6593))
+
+# [1.5.0](https://github.com/jaxzin/ansible-collection-infra/compare/1.4.0...1.5.0) (2026-06-17)
+
+
+### Features
+
+* **tailscale_sidecar:** fail fast on expired/revoked auth key ([#9](https://github.com/jaxzin/ansible-collection-infra/issues/9)) ([2cfd8cc](https://github.com/jaxzin/ansible-collection-infra/commit/2cfd8cc079df560f6b226ac06502ed3f6cdfd146))
+
+# [1.4.0](https://github.com/jaxzin/ansible-collection-infra/compare/1.3.0...1.4.0) (2026-06-17)
+
+
+### Features
+
+* **tailscale_sidecar:** self-heal DNS so tailscaled's empty DefaultResolvers can't break the netns ([#8](https://github.com/jaxzin/ansible-collection-infra/issues/8)) ([3c86b42](https://github.com/jaxzin/ansible-collection-infra/commit/3c86b42fb6148cc65586c270a3d81a545dc1cc4b)), closes [#7](https://github.com/jaxzin/ansible-collection-infra/issues/7)
+
+# [1.3.0](https://github.com/jaxzin/ansible-collection-infra/compare/1.2.0...1.3.0) (2026-06-16)
+
+
+### Bug Fixes
+
+* require ansible-core >=2.15 (drop EOL ansible-core 2.14) ([84691fe](https://github.com/jaxzin/ansible-collection-infra/commit/84691fee79cea0e4557de4cd1a33e4a1bb428ac0))
+
+
+### Features
+
+* declare community.docker (>=3.0.0) runtime dependency ([b39a3dc](https://github.com/jaxzin/ansible-collection-infra/commit/b39a3dc29aaea2f4457d45f1b8db62e2afd8f44f))
+
+## [1.2.0] - 2026-06-15
+
+### Added
+
+- `tailscale_sidecar`: configurable `tailscale_log_driver` /
+  `tailscale_log_options` (default `json-file`) so the sidecar avoids the
+  Synology ContainerManager `db` log driver, which wedges and breaks
+  healthcheck execs and container restarts.
+
+## [1.1.0] - 2026-05-05
+
+### Added
+
+- `tailscale_sidecar`: configurable container memory limits
+  (`tailscale_memory_limit` / `tailscale_memory_swap`).
+- `tailscale_sidecar`: configurable `TS_ACCEPT_DNS` via `tailscale_accept_dns`,
+  for sidecars that must resolve other containers via Docker's embedded DNS.
+
+## [1.0.0] - 2026-02-25
+
+### Added
+
+- Initial release of the `jaxzin.infra` collection with the `tailscale_sidecar`
+  role: deploys a Tailscale sidecar container with an optional Tailscale Serve
+  HTTPS reverse proxy.

--- a/playbooks/collections/ansible_collections/jaxzin/infra/LICENSE
+++ b/playbooks/collections/ansible_collections/jaxzin/infra/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Brian R. Jackson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/playbooks/collections/ansible_collections/jaxzin/infra/README.md
+++ b/playbooks/collections/ansible_collections/jaxzin/infra/README.md
@@ -1,0 +1,71 @@
+# Ansible Collection - jaxzin.infra
+
+Shared infrastructure roles for homelab services on Synology DSM with Tailscale networking.
+
+## Roles
+
+### `jaxzin.infra.tailscale_sidecar`
+
+Deploys a Tailscale sidecar container with optional [Tailscale Serve](https://tailscale.com/kb/1312/serve) reverse proxy. The sidecar joins your tailnet and can expose services via HTTPS using Tailscale's built-in TLS.
+
+**Supports two networking patterns:**
+
+1. **Shared namespace** (default): The app container uses `network_mode: container:<sidecar>` to share the sidecar's network stack. Serve proxies to `127.0.0.1`.
+2. **Docker DNS**: The app and sidecar are on the same Docker network. Serve proxies to the app's container name via Docker DNS. Set `tailscale_serve_proxy_host` to the app's container name.
+
+#### Example: Shared namespace (default)
+
+```yaml
+- role: jaxzin.infra.tailscale_sidecar
+  vars:
+    tailscale_container_name: tailscale-myapp
+    tailscale_hostname: myapp
+    tailscale_authkey: "{{ lookup('ansible.builtin.env', 'TS_AUTHKEY') }}"
+    tailscale_state_dir: /volume1/docker/myapp/tailscale-state
+    tailscale_network_name: myapp-net
+    tailscale_serve_enabled: true
+    tailscale_serve_config_dir: /volume1/docker/myapp/tailscale-serve-config
+    tailscale_serve_domain: "myapp.example.ts.net"
+    tailscale_serve_proxy_port: "3000"
+```
+
+#### Example: Docker DNS (multi-container)
+
+```yaml
+- role: jaxzin.infra.tailscale_sidecar
+  vars:
+    tailscale_container_name: tailscale-myapp
+    tailscale_hostname: myapp
+    tailscale_authkey: "{{ lookup('ansible.builtin.env', 'TS_AUTHKEY') }}"
+    tailscale_state_dir: /volume1/docker/myapp/tailscale-state
+    tailscale_network_name: myapp-net
+    tailscale_serve_enabled: true
+    tailscale_serve_config_dir: /volume1/docker/myapp/tailscale-serve-config
+    tailscale_serve_domain: "myapp.example.ts.net"
+    tailscale_serve_proxy_host: "myapp-server"
+    tailscale_serve_proxy_port: "9000"
+```
+
+## Installation
+
+```bash
+ansible-galaxy collection install jaxzin.infra
+```
+
+Or via `requirements.yml`:
+
+```yaml
+collections:
+  - name: jaxzin.infra
+    version: ">=1.0.0"
+```
+
+## Requirements
+
+- Ansible >= 2.14
+- `community.docker` collection
+- Docker on the target host
+
+## License
+
+MIT

--- a/playbooks/collections/ansible_collections/jaxzin/infra/galaxy.yml
+++ b/playbooks/collections/ansible_collections/jaxzin/infra/galaxy.yml
@@ -1,0 +1,35 @@
+namespace: jaxzin
+name: infra
+version: 1.6.0
+readme: README.md
+authors:
+  - Brian R. Jackson <brian@jaxzin.com>
+description: Shared infrastructure roles for homelab services
+license:
+  - MIT
+tags:
+  - synology
+  - tailscale
+  - homelab
+  - sidecar
+  - infrastructure
+  - networking
+dependencies:
+  community.docker: ">=3.0.0"
+repository: https://github.com/jaxzin/ansible-collection-infra
+documentation: https://github.com/jaxzin/ansible-collection-infra
+homepage: https://github.com/jaxzin/ansible-collection-infra
+issues: https://github.com/jaxzin/ansible-collection-infra/issues
+build_ignore:
+  - '*.tar.gz'
+  - .gitignore
+  - .github
+  - .ansible
+  - .venv
+  - node_modules
+  - package.json
+  - package-lock.json
+  - .releaserc.json
+  - scripts
+  - docs
+  - roles/tailscale_sidecar/tests

--- a/playbooks/collections/ansible_collections/jaxzin/infra/meta/runtime.yml
+++ b/playbooks/collections/ansible_collections/jaxzin/infra/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.15.0"

--- a/playbooks/collections/ansible_collections/jaxzin/infra/roles/tailscale_sidecar/README.md
+++ b/playbooks/collections/ansible_collections/jaxzin/infra/roles/tailscale_sidecar/README.md
@@ -1,0 +1,119 @@
+# tailscale_sidecar
+
+Deploys a Tailscale sidecar container with optional [Tailscale Serve](https://tailscale.com/kb/1312/serve) reverse proxy.
+
+## Requirements
+
+- `community.docker` collection
+- Docker on the target host
+
+## Role Variables
+
+See `defaults/main.yml` for defaults and `meta/main.yml` for full argument specs.
+
+### Required
+
+| Variable | Description |
+|----------|-------------|
+| `tailscale_container_name` | Name for the Tailscale sidecar container |
+| `tailscale_hostname` | Hostname on the tailnet |
+| `tailscale_authkey` | Tailscale auth key |
+| `tailscale_state_dir` | Host path for persistent Tailscale state |
+| `tailscale_network_name` | Docker network to join |
+
+### Serve (optional)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `tailscale_serve_enabled` | `false` | Enable Tailscale Serve reverse proxy |
+| `tailscale_serve_config_dir` | `""` | Host path for serve config |
+| `tailscale_serve_domain` | `""` | FQDN for the HTTPS endpoint |
+| `tailscale_serve_proxy_host` | `127.0.0.1` | Backend host to proxy to |
+| `tailscale_serve_proxy_port` | `""` | Backend port to proxy to |
+
+### Networking mode
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `tailscale_userspace_networking` | `false` | `false` = **kernel mode**: tailscaled brings up a kernel TUN interface, so the container gets `CAP_NET_ADMIN` + `CAP_SYS_MODULE` and the `/dev/net/tun` device. `true` = **userspace mode**: WireGuard runs entirely in user space, so the role **drops** those capabilities and the `/dev/net/tun` mount and exposes a SOCKS5 proxy on `:1055` and an outbound HTTP CONNECT proxy on `:1099` so peer containers can route outbound tailnet traffic through this sidecar. See [userspace networking](https://tailscale.com/kb/1112/userspace-networking). |
+
+### DNS
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `tailscale_accept_dns` | `true` | Whether tailscaled takes over `/etc/resolv.conf`. Set to `false` when the sidecar lives on a Docker bridge network and `tailscale_serve_proxy_host` is a Docker DNS name (e.g., `myapp-server`); otherwise tailscaled rewrites resolv.conf to point only at MagicDNS (`100.100.100.100`), which can't resolve Docker peer names. |
+
+### DNS self-heal & upstream watchdog
+
+In kernel-mode + shared-netns deployments, `tailscaled` can finish startup
+without applying the tailnet DNS config to its forwarder (`DefaultResolvers`
+ends up empty), so MagicDNS (`100.100.100.100`) returns **SERVFAIL for every
+query** and all outbound DNS in the shared netns breaks silently — while the
+serve/funnel path keeps working. See
+[issue #7](https://github.com/jaxzin/ansible-collection-infra/issues/7).
+
+The role installs a healthcheck script (`dns-watchdog.sh`) on the sidecar that,
+on each interval:
+
+1. **Downstream heal** — re-prepends Docker's embedded resolver (`127.0.0.11`)
+   to `/etc/resolv.conf` so containers sharing this netns keep resolving Docker
+   service names (tailscaled strips it on every restart).
+2. **Upstream watchdog** — when `tailscale_accept_dns` is `true`, probes an
+   external name against MagicDNS; if it SERVFAILs, it bounces
+   `accept-dns` false→true to force tailscaled to re-apply its DNS config
+   (verified non-disruptive). After the bounce it re-probes and reports the
+   container `unhealthy` only if DNS is still broken — informational only, since
+   `restart_policy: always` does not restart unhealthy containers.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `tailscale_dns_watchdog_enabled` | `true` | Enable the self-heal + watchdog healthcheck. Disabling removes both halves. |
+| `tailscale_dns_servers` | `["100.100.100.100"]` | Container `dns_servers`; gives `127.0.0.11` a working upstream. `[]` leaves Docker's default. |
+| `tailscale_dns_probe_name` | `one.one.one.one` | External name the watchdog resolves. |
+| `tailscale_dns_probe_resolver` | `100.100.100.100` | Resolver the watchdog queries. |
+| `tailscale_dns_watchdog_interval` | `15s` | Healthcheck interval. |
+| `tailscale_dns_watchdog_timeout` | `10s` | Healthcheck timeout. |
+| `tailscale_dns_watchdog_retries` | `3` | Failures before reported unhealthy. |
+| `tailscale_dns_watchdog_start_period` | `10s` | Grace period before failures count. |
+| `tailscale_dns_watchdog_host_dir` | sibling of `tailscale_state_dir` (…/tailscale-dns-watchdog) | Host dir the script is installed into and mounted from. |
+
+### Connection verification
+
+After deploying the container, the role waits for `tailscaled` to reach
+`Running`, then **fails fast with an actionable message** if the sidecar did
+not authenticate — the classic signature of an **expired or revoked
+`TS_AUTHKEY`** (`BackendState` of `NeedsLogin`, `NoState`, or
+`NeedsMachineAuth`). It then asserts the sidecar is `Running` and
+`Self.Online`. Persistent sidecars require a **reusable, non-ephemeral** auth
+key.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `tailscale_assert_tailnet_route` | `false` | Also assert the sidecar has ≥1 tailnet peer (a usable **outbound** route). Leave `false` for inbound/Serve-only sidecars, where a single-node or peer-less tailnet is valid. Set `true` when workloads proxy outbound through this sidecar, so a "registered but not routing" sidecar (zero peers → `ENETUNREACH`) fails the play fast. |
+
+### Logging
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `tailscale_log_driver` | `json-file` | Docker logging driver for the sidecar. Defaults to `json-file` (local-file logging) so the container never lands on the Synology ContainerManager `db` driver, which wedges and breaks healthchecks + restarts. |
+| `tailscale_log_options` | `{max-size: "10m", max-file: "3"}` | Driver-specific log options. The default rotates json-file logs at 10 MB, keeping 3 files. Must be compatible with `tailscale_log_driver` if overridden. |
+
+## Example Playbook
+
+```yaml
+- role: jaxzin.infra.tailscale_sidecar
+  vars:
+    tailscale_container_name: tailscale-myapp
+    tailscale_hostname: myapp
+    tailscale_authkey: "{{ lookup('ansible.builtin.env', 'TS_AUTHKEY') }}"
+    tailscale_state_dir: /volume1/docker/myapp/tailscale-state
+    tailscale_network_name: myapp-net
+    tailscale_serve_enabled: true
+    tailscale_serve_config_dir: /volume1/docker/myapp/tailscale-serve-config
+    tailscale_serve_domain: "myapp.example.ts.net"
+    tailscale_serve_proxy_port: "3000"
+```
+
+## License
+
+MIT

--- a/playbooks/collections/ansible_collections/jaxzin/infra/roles/tailscale_sidecar/defaults/main.yml
+++ b/playbooks/collections/ansible_collections/jaxzin/infra/roles/tailscale_sidecar/defaults/main.yml
@@ -1,0 +1,82 @@
+---
+tailscale_image: "ghcr.io/tailscale/tailscale:latest"
+tailscale_serve_enabled: false
+tailscale_serve_config_src: "ts-serve.json.j2"
+tailscale_serve_config_dir: ""
+tailscale_serve_domain: ""
+tailscale_serve_proxy_host: "127.0.0.1"
+tailscale_serve_proxy_port: ""
+tailscale_host_ports: []
+tailscale_extra_args: ""
+
+# Networking mode. false (default) = kernel mode: tailscaled brings up a kernel
+# TUN interface, which needs CAP_NET_ADMIN + CAP_SYS_MODULE and the
+# /dev/net/tun device. true = userspace mode: WireGuard runs entirely in user
+# space, so the role drops those capabilities and the /dev/net/tun mount and
+# exposes a SOCKS5 proxy on :1055 and an outbound HTTP CONNECT proxy on :1099 so
+# peer containers can route outbound tailnet traffic through this sidecar.
+# https://tailscale.com/kb/1112/userspace-networking
+tailscale_userspace_networking: false
+
+# Whether tailscaled inside the sidecar should take over /etc/resolv.conf.
+# Set to false when the sidecar lives on a Docker bridge network and must
+# resolve other containers by name via Docker's embedded DNS at 127.0.0.11
+# (e.g., when tailscale_serve_proxy_host is a Docker DNS name like
+# `myapp-server`). With true (the default, preserving prior behavior),
+# tailscaled rewrites /etc/resolv.conf to point only at 100.100.100.100,
+# which makes Docker DNS unreachable from inside the sidecar.
+tailscale_accept_dns: true
+
+# Container resource limits
+tailscale_memory_limit: "96m"
+tailscale_memory_swap: "192m"
+
+# Container logging. Pin json-file (local-file) logging by default so the
+# sidecar never lands on the Synology ContainerManager `db` log driver,
+# which wedges (locks/hangs) and breaks both healthcheck execs and container
+# (re)starts. Consumers may override per deploy.
+tailscale_log_driver: "json-file"
+tailscale_log_options:
+  max-size: "10m"
+  max-file: "3"
+
+# After the sidecar reaches Running, also assert it has at least one tailnet
+# peer (a usable OUTBOUND route). Leave false for inbound/Serve-only sidecars,
+# where a single-node or peer-less tailnet is valid and would otherwise fail
+# this check. Set true when workloads proxy outbound through this sidecar so a
+# "registered but not routing" sidecar (zero peers -> ENETUNREACH) fails the
+# play fast instead of failing opaquely later.
+tailscale_assert_tailnet_route: false
+
+# --- DNS self-heal & upstream watchdog (issue #7) ---
+# Upstream DNS servers set on the sidecar container (Docker dns_servers).
+# Defaults to MagicDNS so Docker's embedded resolver (127.0.0.11) has a working
+# upstream: Docker names -> 127.0.0.11; tailnet/external -> 127.0.0.11 ->
+# 100.100.100.100 -> Cloudflare. Set to [] to leave Docker's default wiring.
+tailscale_dns_servers:
+  - "100.100.100.100"
+
+# Master toggle for the DNS self-heal + upstream watchdog Docker healthcheck.
+# Disabling removes BOTH self-heal halves (downstream resolv.conf heal and the
+# upstream forwarder watchdog), since Docker allows only one healthcheck.
+tailscale_dns_watchdog_enabled: true
+
+# External name the watchdog resolves to verify tailscaled's forwarder has
+# working upstreams. Only used when both tailscale_dns_watchdog_enabled and
+# tailscale_accept_dns are true.
+tailscale_dns_probe_name: "one.one.one.one"
+# Resolver the watchdog queries for tailscale_dns_probe_name. Defaults to
+# MagicDNS (100.100.100.100) — the resolver tailscaled manages — so querying
+# it directly detects the empty-DefaultResolvers condition.
+tailscale_dns_probe_resolver: "100.100.100.100"
+
+# Docker healthcheck cadence for the watchdog.
+tailscale_dns_watchdog_interval: "15s"
+tailscale_dns_watchdog_timeout: "10s"
+tailscale_dns_watchdog_retries: 3
+tailscale_dns_watchdog_start_period: "10s"
+
+# Host directory the watchdog script (dns-watchdog.sh) is installed into and
+# bind-mounted from. Defaults to a sibling of the state dir so it lands in the
+# operator's docker tree (e.g. /volume1/docker/myapp/tailscale-dns-watchdog).
+tailscale_dns_watchdog_host_dir: "{{ tailscale_state_dir | dirname }}/tailscale-dns-watchdog"

--- a/playbooks/collections/ansible_collections/jaxzin/infra/roles/tailscale_sidecar/files/dns-watchdog.sh
+++ b/playbooks/collections/ansible_collections/jaxzin/infra/roles/tailscale_sidecar/files/dns-watchdog.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# dns-watchdog.sh — Docker healthcheck for the jaxzin.infra tailscale_sidecar.
+#
+# Fixes jaxzin.infra#7: in kernel-mode + shared-netns deployments, tailscaled
+# can boot with an empty DefaultResolvers list, so MagicDNS (100.100.100.100)
+# returns SERVFAIL for every query and all outbound DNS in the shared netns
+# breaks. This script runs on the container's healthcheck interval and:
+#
+#   1. Downstream heal: keeps Docker's embedded resolver (127.0.0.11) at the
+#      top of resolv.conf so containers sharing this netns can resolve Docker
+#      service names. tailscaled (accept-dns=true) strips it on every restart.
+#   2. Upstream watchdog: probes an external name against MagicDNS; if it
+#      SERVFAILs (the empty-DefaultResolvers condition), it bounces accept-dns
+#      false->true to force tailscaled to re-apply netmap DNS to its forwarder.
+#      Verified non-disruptive — consumers stay up across the bounce.
+#
+# Exit 0 = healthy; exit 1 = upstream DNS still broken after a bounce attempt.
+#
+# Configuration (environment; the role injects these, defaults keep it runnable
+# standalone and are what the bats tests drive):
+#   RESOLV_CONF            resolv.conf path           (default /etc/resolv.conf)
+#   TS_DNS_DOCKER_RESOLVER nameserver to keep on top  (default 127.0.0.11)
+#   TS_DNS_ACCEPT_DNS      desired accept-dns value   (default true)
+#   TS_DNS_PROBE_NAME      external name to resolve   (default one.one.one.one)
+#   TS_DNS_PROBE_RESOLVER  resolver to query          (default 100.100.100.100)
+#   TS_DNS_BOUNCE_SETTLE   seconds to wait mid-bounce (default 2)
+
+set -u
+
+RESOLV_CONF="${RESOLV_CONF:-/etc/resolv.conf}"
+DOCKER_RESOLVER="${TS_DNS_DOCKER_RESOLVER:-127.0.0.11}"
+ACCEPT_DNS="${TS_DNS_ACCEPT_DNS:-true}"
+PROBE_NAME="${TS_DNS_PROBE_NAME:-one.one.one.one}"
+PROBE_RESOLVER="${TS_DNS_PROBE_RESOLVER:-100.100.100.100}"
+SETTLE="${TS_DNS_BOUNCE_SETTLE:-2}"
+
+# 1. Downstream heal — ensure DOCKER_RESOLVER is the first nameserver line.
+# Idempotent. Never `sed -i`: rename() returns EBUSY on the resolv.conf bind
+# mount. Stage in a temp file, then overwrite in place with `>` (open+truncate).
+heal_resolv_conf() {
+    if grep -q "^nameserver ${DOCKER_RESOLVER}$" "$RESOLV_CONF"; then
+        return 0
+    fi
+    _tmp="${TMPDIR:-/tmp}/dns-watchdog.resolv.$$"
+    { printf 'nameserver %s\n' "$DOCKER_RESOLVER"; cat "$RESOLV_CONF"; } > "$_tmp" &&
+        cat "$_tmp" > "$RESOLV_CONF"
+    _rc=$?
+    rm -f "$_tmp"
+    [ "$_rc" -eq 0 ] && grep -q "^nameserver ${DOCKER_RESOLVER}$" "$RESOLV_CONF"
+}
+
+# 2. Upstream probe — can MagicDNS resolve an external name? busybox nslookup
+# exits non-zero on SERVFAIL / empty answer. Bound it with `timeout` when
+# available (busybox has it; some dev machines do not).
+probe_upstream() {
+    if command -v timeout >/dev/null 2>&1; then
+        timeout 2 nslookup "$PROBE_NAME" "$PROBE_RESOLVER" >/dev/null 2>&1
+    else
+        nslookup "$PROBE_NAME" "$PROBE_RESOLVER" >/dev/null 2>&1
+    fi
+}
+
+# 3. Force tailscaled to re-apply netmap DNS to its forwarder.
+bounce_accept_dns() {
+    echo "dns-watchdog: upstream SERVFAIL detected; bouncing accept-dns to force re-apply" >&2
+    tailscale set --accept-dns=false >/dev/null 2>&1
+    sleep "$SETTLE"
+    tailscale set --accept-dns="$ACCEPT_DNS" >/dev/null 2>&1
+}
+
+main() {
+    heal_resolv_conf || exit 1
+
+    # The upstream watchdog only applies when tailscaled manages DNS
+    # (accept-dns=true). With accept-dns=false, external names are not expected
+    # to resolve via MagicDNS, so probing/bouncing would be wrong.
+    [ "$ACCEPT_DNS" = "true" ] || exit 0
+
+    if probe_upstream; then
+        exit 0
+    fi
+
+    bounce_accept_dns
+
+    if probe_upstream; then
+        exit 0
+    fi
+    exit 1
+}
+
+main

--- a/playbooks/collections/ansible_collections/jaxzin/infra/roles/tailscale_sidecar/meta/main.yml
+++ b/playbooks/collections/ansible_collections/jaxzin/infra/roles/tailscale_sidecar/meta/main.yml
@@ -1,0 +1,219 @@
+galaxy_info:
+  role_name: tailscale_sidecar
+  author: Brian R. Jackson
+  description: Deploy a Tailscale sidecar container with optional Tailscale Serve reverse proxy
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
+
+argument_specs:
+  main:
+    short_description: Deploy a Tailscale sidecar container
+    options:
+      tailscale_container_name:
+        type: str
+        required: true
+        description: Name of the Tailscale sidecar Docker container
+
+      tailscale_image:
+        type: str
+        default: "ghcr.io/tailscale/tailscale:latest"
+        description: Tailscale container image
+
+      tailscale_hostname:
+        type: str
+        required: true
+        description: Tailscale hostname for this node on the tailnet
+
+      tailscale_authkey:
+        type: str
+        required: true
+        description: Tailscale auth key (from TS_AUTHKEY env var)
+
+      tailscale_state_dir:
+        type: str
+        required: true
+        description: Host path for Tailscale persistent state
+
+      tailscale_network_name:
+        type: str
+        required: true
+        description: Docker network to attach the sidecar to
+
+      tailscale_serve_enabled:
+        type: bool
+        default: false
+        description: Whether to enable Tailscale Serve (HTTPS reverse proxy)
+
+      tailscale_serve_config_src:
+        type: str
+        default: "ts-serve.json.j2"
+        description: Jinja2 template for the Serve config (relative to role templates/)
+
+      tailscale_serve_config_dir:
+        type: str
+        default: ""
+        description: Host path for the rendered Serve config (required when serve_enabled=true)
+
+      tailscale_serve_domain:
+        type: str
+        default: ""
+        description: >-
+          The FQDN for Tailscale Serve (e.g., myapp.example.ts.net).
+          Required when serve_enabled=true.
+
+      tailscale_serve_proxy_host:
+        type: str
+        default: "127.0.0.1"
+        description: >-
+          Host/IP the Serve proxy target points to.
+          Use 127.0.0.1 when the app shares the sidecar network namespace (network_mode: container:).
+          Use a Docker DNS name (e.g., myapp-server) when containers are on the same Docker network.
+
+      tailscale_serve_proxy_port:
+        type: str
+        default: ""
+        description: Port for the Serve proxy target. Required when serve_enabled=true.
+
+      tailscale_host_ports:
+        type: list
+        elements: str
+        default: []
+        description: >-
+          Host port mappings for the sidecar container (e.g., ["127.0.0.1:8080:8080"]).
+          Only needed if you want localhost access to the proxied service.
+
+      tailscale_extra_args:
+        type: str
+        default: ""
+        description: Extra arguments passed to tailscaled via TS_EXTRA_ARGS
+
+      tailscale_userspace_networking:
+        type: bool
+        default: false
+        description: >-
+          Networking mode. false (default) runs kernel mode: tailscaled brings
+          up a kernel TUN interface, requiring CAP_NET_ADMIN + CAP_SYS_MODULE
+          and the /dev/net/tun device. true runs userspace mode: WireGuard runs
+          entirely in user space, so the role drops those capabilities and the
+          /dev/net/tun mount and exposes a SOCKS5 proxy on :1055 and an outbound
+          HTTP CONNECT proxy on :1099 so peer containers can route outbound
+          tailnet traffic through this sidecar. See
+          https://tailscale.com/kb/1112/userspace-networking
+
+      tailscale_accept_dns:
+        type: bool
+        default: true
+        description: >-
+          Whether tailscaled inside the sidecar takes over /etc/resolv.conf
+          (TS_ACCEPT_DNS). Set to false when the sidecar is on a Docker bridge
+          network and must resolve other containers by name via Docker's
+          embedded DNS at 127.0.0.11 — for example, when
+          tailscale_serve_proxy_host is a Docker DNS name like `myapp-server`.
+          With true (the default), tailscaled rewrites /etc/resolv.conf to
+          point only at 100.100.100.100 (MagicDNS), making Docker DNS
+          unreachable from inside the sidecar.
+
+      tailscale_log_driver:
+        type: str
+        default: "json-file"
+        description: >-
+          Docker logging driver for the sidecar container. Defaults to
+          json-file (local-file logging with rotation) so the container never
+          uses the Synology ContainerManager `db` driver, which wedges and
+          breaks healthchecks and container restarts.
+
+      tailscale_log_options:
+        type: dict
+        default:
+          max-size: "10m"
+          max-file: "3"
+        description: >-
+          Options passed to the logging driver (driver-specific). The default
+          rotates json-file logs at 10 MB, keeping 3 files. Must be compatible
+          with tailscale_log_driver if you override it.
+
+      tailscale_assert_tailnet_route:
+        type: bool
+        default: false
+        description: >-
+          After the sidecar reaches Running, also assert it has at least one
+          tailnet peer (a usable outbound route). Leave false for
+          inbound/Serve-only sidecars, where a single-node or peer-less tailnet
+          is valid and would otherwise fail this check. Set true when workloads
+          proxy outbound through this sidecar so a registered-but-not-routing
+          sidecar (zero peers, ENETUNREACH) fails the play fast.
+
+      tailscale_dns_servers:
+        type: list
+        elements: str
+        default:
+          - "100.100.100.100"
+        description: >-
+          Upstream DNS servers set on the sidecar container (Docker
+          dns_servers). Defaults to MagicDNS (100.100.100.100) so Docker's
+          embedded resolver (127.0.0.11) has a working upstream. Set to [] to
+          leave Docker's default resolver wiring untouched.
+
+      tailscale_dns_watchdog_enabled:
+        type: bool
+        default: true
+        description: >-
+          Enable the DNS self-heal + upstream watchdog Docker healthcheck
+          (issue #7). Keeps Docker's embedded resolver (127.0.0.11) at the top
+          of resolv.conf and, when tailscale_accept_dns is true, detects the
+          empty-DefaultResolvers SERVFAIL condition and bounces accept-dns to
+          force tailscaled to re-apply DNS. Disabling removes BOTH self-heal
+          halves.
+
+      tailscale_dns_probe_name:
+        type: str
+        default: "one.one.one.one"
+        description: >-
+          External hostname the watchdog resolves to verify tailscaled's
+          forwarder has working upstreams. Only used when
+          tailscale_dns_watchdog_enabled and tailscale_accept_dns are true.
+
+      tailscale_dns_probe_resolver:
+        type: str
+        default: "100.100.100.100"
+        description: >-
+          Resolver the watchdog queries for tailscale_dns_probe_name. Defaults
+          to MagicDNS (100.100.100.100) — the resolver tailscaled manages — so
+          querying it directly detects the empty-DefaultResolvers condition.
+          Only used when tailscale_dns_watchdog_enabled and tailscale_accept_dns
+          are true.
+
+      tailscale_dns_watchdog_interval:
+        type: str
+        default: "15s"
+        description: Docker healthcheck interval for the DNS watchdog.
+
+      tailscale_dns_watchdog_timeout:
+        type: str
+        default: "10s"
+        description: Docker healthcheck timeout for the DNS watchdog.
+
+      tailscale_dns_watchdog_retries:
+        type: int
+        default: 3
+        description: >-
+          Docker healthcheck retries before the sidecar is reported unhealthy.
+
+      tailscale_dns_watchdog_start_period:
+        type: str
+        default: "10s"
+        description: Docker healthcheck start period before failures count.
+
+      tailscale_dns_watchdog_host_dir:
+        type: str
+        description: >-
+          Host directory the watchdog script (dns-watchdog.sh) is installed into
+          and bind-mounted from. Defaults (in defaults/main.yml) to a
+          tailscale-dns-watchdog sibling of tailscale_state_dir.

--- a/playbooks/collections/ansible_collections/jaxzin/infra/roles/tailscale_sidecar/tasks/main.yml
+++ b/playbooks/collections/ansible_collections/jaxzin/infra/roles/tailscale_sidecar/tasks/main.yml
@@ -1,0 +1,209 @@
+---
+- name: Create Tailscale state directory
+  ansible.builtin.file:
+    path: "{{ tailscale_state_dir }}"
+    state: directory
+    mode: "0700"
+
+- name: Create DNS watchdog script directory on the host
+  ansible.builtin.file:
+    path: "{{ tailscale_dns_watchdog_host_dir }}"
+    state: directory
+    mode: "0755"
+  when: tailscale_dns_watchdog_enabled
+
+- name: Install the DNS watchdog script on the host
+  ansible.builtin.copy:
+    src: dns-watchdog.sh
+    dest: "{{ tailscale_dns_watchdog_host_dir }}/dns-watchdog.sh"
+    mode: "0755"
+  when: tailscale_dns_watchdog_enabled
+
+- name: Create Tailscale Serve config directory
+  ansible.builtin.file:
+    path: "{{ tailscale_serve_config_dir }}"
+    state: directory
+    mode: "0755"
+  when: tailscale_serve_enabled
+
+- name: Render Tailscale Serve config
+  ansible.builtin.template:
+    src: "{{ tailscale_serve_config_src }}"
+    dest: "{{ tailscale_serve_config_dir }}/serve.json"
+    mode: "0644"
+  when: tailscale_serve_enabled
+
+- name: Deploy Tailscale sidecar container
+  community.docker.docker_container:
+    name: "{{ tailscale_container_name }}"
+    image: "{{ tailscale_image }}"
+    state: started
+    restart_policy: always
+    dns_servers: "{{ tailscale_dns_servers if (tailscale_dns_servers | length > 0) else omit }}"
+    healthcheck: >-
+      {{
+        {
+          'test': ['CMD', '/bin/sh', '/usr/local/bin/dns-watchdog.sh'],
+          'interval': tailscale_dns_watchdog_interval,
+          'timeout': tailscale_dns_watchdog_timeout,
+          'retries': tailscale_dns_watchdog_retries,
+          'start_period': tailscale_dns_watchdog_start_period,
+        }
+        if tailscale_dns_watchdog_enabled else omit
+      }}
+    log_driver: "{{ tailscale_log_driver }}"
+    log_options: "{{ tailscale_log_options }}"
+    networks:
+      - name: "{{ tailscale_network_name }}"
+    ports: "{{ tailscale_host_ports }}"
+    memory: "{{ tailscale_memory_limit }}"
+    memory_swap: "{{ tailscale_memory_swap }}"
+    # Kernel-mode Tailscale needs CAP_NET_ADMIN + CAP_SYS_MODULE and the
+    # /dev/net/tun device (mounted below) to bring up its kernel TUN interface.
+    # Userspace mode (TS_USERSPACE=true) routes WireGuard entirely in user
+    # space, so neither is needed — granting them anyway over-privileges the
+    # container. Conditional: kernel mode only (else omit drops the key).
+    capabilities: >-
+      {{
+        ['NET_ADMIN', 'SYS_MODULE']
+        if not (tailscale_userspace_networking | bool) else omit
+      }}
+    # TS_DNS_ACCEPT_DNS mirrors TS_ACCEPT_DNS (image entrypoint) on purpose — the watchdog script reads its own key; do not dedupe.
+    env: >-
+      {{
+        {
+          'TS_HOSTNAME': tailscale_hostname,
+          'TS_AUTHKEY': tailscale_authkey,
+          'TS_STATE_DIR': '/var/lib/tailscale',
+          'TS_USERSPACE': tailscale_userspace_networking | bool | string | lower,
+          'TS_ACCEPT_DNS': tailscale_accept_dns | string | lower,
+        }
+        | combine(
+            {'TS_SERVE_CONFIG': '/etc/tailscale/serve.json'}
+            if tailscale_serve_enabled else {}
+          )
+        | combine(
+            {'TS_EXTRA_ARGS': tailscale_extra_args}
+            if tailscale_extra_args else {}
+          )
+        | combine(
+            {
+              'TS_DNS_ACCEPT_DNS': tailscale_accept_dns | string | lower,
+              'TS_DNS_PROBE_NAME': tailscale_dns_probe_name,
+              'TS_DNS_PROBE_RESOLVER': tailscale_dns_probe_resolver,
+            }
+            if tailscale_dns_watchdog_enabled else {}
+          )
+        | combine(
+            {
+              'TS_SOCKS5_SERVER': ':1055',
+              'TS_OUTBOUND_HTTP_PROXY_LISTEN': ':1099',
+            }
+            if tailscale_userspace_networking | bool else {}
+          )
+      }}
+    # /dev/net/tun is bind-mounted only in kernel mode (see capabilities above);
+    # userspace mode never opens the device.
+    volumes: >-
+      {{
+        [tailscale_state_dir ~ ':/var/lib/tailscale']
+        + (
+            ['/dev/net/tun:/dev/net/tun']
+            if not (tailscale_userspace_networking | bool) else []
+          )
+        + (
+            [tailscale_serve_config_dir ~ ':/etc/tailscale:ro']
+            if tailscale_serve_enabled else []
+          )
+        + (
+            [tailscale_dns_watchdog_host_dir ~ '/dns-watchdog.sh:/usr/local/bin/dns-watchdog.sh:ro']
+            if tailscale_dns_watchdog_enabled else []
+          )
+      }}
+
+- name: Wait for Tailscale to connect to tailnet
+  community.docker.docker_container_exec:
+    container: "{{ tailscale_container_name }}"
+    command: tailscale status --json
+  register: ts_status
+  # rc guard: a failed exec or empty stdout must not crash from_json. Jinja
+  # `and` short-circuits, so BackendState is only parsed once rc == 0.
+  until: >-
+    ts_status.rc is defined and ts_status.rc == 0 and
+    (ts_status.stdout | from_json).BackendState == "Running"
+  retries: 30
+  delay: 2
+  changed_when: false
+  # Do NOT hard-fail on retry exhaustion: the tasks below turn a dead/expired
+  # TS_AUTHKEY or a "registered but not routing" sidecar into a named,
+  # actionable error instead of an opaque "until" timeout.
+  failed_when: false
+  when: not ansible_check_mode
+
+- name: Parse final Tailscale status
+  ansible.builtin.set_fact:
+    ts_state: >-
+      {{ (ts_status.stdout | from_json)
+         if (ts_status.stdout is defined and (ts_status.stdout | length) > 0)
+         else {} }}
+  when: not ansible_check_mode
+
+- name: Fail fast when the Tailscale auth key is expired or revoked
+  ansible.builtin.fail:
+    msg: >-
+      Tailscale sidecar '{{ tailscale_container_name }}' did not authenticate
+      (BackendState={{ ts_state.BackendState | default('unknown') }}). This is
+      the classic signature of an expired or revoked TS_AUTHKEY. Rotate the auth
+      key in the Tailscale admin console and update it wherever this role's
+      tailscale_authkey is sourced. Persistent sidecars require a reusable,
+      non-ephemeral auth key.
+  when:
+    - not ansible_check_mode
+    - ts_state.BackendState | default('') in ['NeedsLogin', 'NoState', 'NeedsMachineAuth']
+
+- name: Assert the Tailscale sidecar authenticated and is online
+  ansible.builtin.assert:
+    that:
+      - ts_state.BackendState | default('') == 'Running'
+      - ts_state.Self.Online | default(false) | bool
+    fail_msg: >-
+      Tailscale sidecar '{{ tailscale_container_name }}' is
+      BackendState={{ ts_state.BackendState | default('unknown') }},
+      Self.Online={{ ts_state.Self.Online | default('?') }} — it did not come up
+      cleanly. If BackendState is not Running, the TS_AUTHKEY is most likely
+      expired or revoked; rotate it (reusable, non-ephemeral).
+    success_msg: >-
+      Tailscale sidecar '{{ tailscale_container_name }}' is Running and online.
+  when: not ansible_check_mode
+
+- name: Assert the Tailscale sidecar has a usable tailnet route
+  ansible.builtin.assert:
+    that:
+      - (ts_state.Peer | default({}) | length) > 0
+    fail_msg: >-
+      Tailscale sidecar '{{ tailscale_container_name }}' is Running but has zero
+      tailnet peers — registered but NOT routing. Workloads proxying outbound
+      through this sidecar would fail with ENETUNREACH. Enable this check only
+      for outbound/proxy sidecars; leave tailscale_assert_tailnet_route=false
+      for inbound/Serve-only sidecars, where a peer-less tailnet is valid.
+    success_msg: >-
+      Tailscale sidecar '{{ tailscale_container_name }}' has
+      {{ ts_state.Peer | default({}) | length }} tailnet peer(s).
+  when:
+    - not ansible_check_mode
+    - tailscale_assert_tailnet_route | bool
+
+- name: Reconcile sidecar DNS immediately after (re)deploy
+  # Runs the watchdog once at deploy time so DNS converges immediately instead
+  # of waiting up to one healthcheck start_period. Non-blocking: failures are
+  # ignored here (failed_when: false) because the healthcheck keeps
+  # reconciling on its interval — a transient miss must not fail the play that
+  # fronts tier-1 services.
+  community.docker.docker_container_exec:
+    container: "{{ tailscale_container_name }}"
+    command: /bin/sh /usr/local/bin/dns-watchdog.sh
+  changed_when: false
+  failed_when: false
+  when:
+    - tailscale_dns_watchdog_enabled
+    - not ansible_check_mode

--- a/playbooks/collections/ansible_collections/jaxzin/infra/roles/tailscale_sidecar/templates/ts-serve.json.j2
+++ b/playbooks/collections/ansible_collections/jaxzin/infra/roles/tailscale_sidecar/templates/ts-serve.json.j2
@@ -1,0 +1,16 @@
+{
+  "TCP": {
+    "443": {
+      "HTTPS": true
+    }
+  },
+  "Web": {
+    "{{ tailscale_serve_domain }}:443": {
+      "Handlers": {
+        "/": {
+          "Proxy": "http://{{ tailscale_serve_proxy_host }}:{{ tailscale_serve_proxy_port }}"
+        }
+      }
+    }
+  }
+}

--- a/playbooks/galaxy-requirements.yml
+++ b/playbooks/galaxy-requirements.yml
@@ -2,5 +2,3 @@
 collections:
   - name: tafeen.synology
     version: "1.0.1"
-  - name: jaxzin.infra
-    version: "1.6.0"

--- a/playbooks/gitea-deploy.yml
+++ b/playbooks/gitea-deploy.yml
@@ -89,6 +89,13 @@
         # Keep the collection's DNS-watchdog scratch dir inside the Gitea
         # docker tree (issue #128 migration note).
         tailscale_dns_watchdog_host_dir: "{{ tailscale_gitea_dns_watchdog_dir }}"
+        # Preserve today's UNCAPPED sidecar (measured live: mem=0 swap=0). The
+        # collection defaults (memory_limit=96m, memory_swap=192m) would newly
+        # OOM-cap tailscaled — an OOM-kill re-breaks DNS, the exact failure this
+        # migration exists to fix. Set BOTH to "0": memory="0" is Docker
+        # "unlimited", which must pair with memory_swap="0".
+        tailscale_memory_limit: "0"
+        tailscale_memory_swap: "0"
         # This sidecar proxies outbound, so preserve the "registered but NOT
         # routing -> ENETUNREACH" guard. The collection defaults this false
         # for Serve-only sidecars (issue #128 migration note).

--- a/tests/check_docker_tasks.py
+++ b/tests/check_docker_tasks.py
@@ -3,6 +3,8 @@
 
 Checks:
   A) network_mode: container:* tasks must not have dns_opts/dns/networks/ports
+  B) the vendored tailscale_sidecar docker_container task must wire
+     TS_ACCEPT_DNS in env (else MagicDNS is disabled in the sidecar)
   C) standalone container tasks should have networks defined (warning)
   D) Gitea Tailscale sidecar tailscale_host_ports must include loopback HTTP
      AND LAN SSH bindings
@@ -27,6 +29,10 @@ import re
 import sys
 
 ROLES_DIR = "playbooks/roles"
+# tailscale_sidecar ships from the vendored jaxzin.infra collection, vendored
+# playbook-adjacent so the dawidd6 deploy + offline tests both resolve the FQCN.
+COLLECTION_ROLES_DIR = "playbooks/collections/ansible_collections/jaxzin/infra/roles"
+TAILSCALE_SIDECAR_TASKS = f"{COLLECTION_ROLES_DIR}/tailscale_sidecar/tasks/main.yml"
 FORBIDDEN_WITH_CONTAINER_MODE = ["dns_opts", "dns:", "dns_search", "networks", "ports"]
 
 DOCKERFILE_PATH = "Dockerfile"
@@ -132,9 +138,14 @@ def has_key_in_block(block, key):
 
 
 def has_env_var(block, var_name):
-    """Check if a specific env var key appears in the task's env: block."""
-    text = "\n".join(block)
-    return var_name in text
+    """Check if a specific env var KEY is wired in the task's env: mapping.
+
+    Matches the key form (YAML ``KEY:`` or Jinja-dict ``'KEY':``) and IGNORES
+    comment lines, so a comment merely mentioning the var name cannot make the
+    check pass vacuously.
+    """
+    text = "\n".join(line for line in block if not line.lstrip().startswith("#"))
+    return re.search(rf"{re.escape(var_name)}['\"]?\s*:", text) is not None
 
 
 def check_file(filepath, errors, warnings):
@@ -227,6 +238,30 @@ RUNNER_FORBIDDEN_NETWORK_MODE_REASON = (
     "container's namespace is a fingerprint of the retired NAS Tailscale-sidecar "
     "architecture. See docs/runbooks/gitea-runner-host.md."
 )
+
+
+def check_b_tailscale_accept_dns(errors):
+    """Check B: the vendored tailscale_sidecar docker_container task must wire
+    TS_ACCEPT_DNS in env (else MagicDNS is disabled in the sidecar)."""
+    try:
+        with open(TAILSCALE_SIDECAR_TASKS) as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        errors.append(f"{TAILSCALE_SIDECAR_TASKS}: File not found")
+        return
+    blocks = split_into_task_blocks(lines)
+    found = False
+    for block in blocks:
+        if not is_docker_container_task(block):
+            continue
+        found = True
+        if not has_env_var(block, "TS_ACCEPT_DNS"):
+            errors.append(
+                f"{TAILSCALE_SIDECAR_TASKS}: Tailscale sidecar docker_container "
+                f"task is missing TS_ACCEPT_DNS in env (MagicDNS would be disabled)"
+            )
+    if not found:
+        errors.append(f"{TAILSCALE_SIDECAR_TASKS}: no docker_container task found")
 
 
 def check_e_runner_no_container_network_mode(errors):
@@ -402,6 +437,9 @@ def main():
 
     # Run check D on the Gitea deploy playbook
     errors.extend(check_d_gitea_sidecar_host_ports())
+
+    # Run check B: the vendored tailscale_sidecar must wire TS_ACCEPT_DNS
+    check_b_tailscale_accept_dns(errors)
 
     # Run check E: gitea-runner must not regress to network_mode: container:*
     check_e_runner_no_container_network_mode(errors)

--- a/tests/test-regression.yml
+++ b/tests/test-regression.yml
@@ -653,36 +653,81 @@
           - "'tailscale_assert_tailnet_route: true' in migration_deploy"
           - "'tailscale_dns_watchdog_host_dir' in migration_deploy"
           - "'when: tailscale_enabled | bool' in migration_deploy"
-          - "'jaxzin.infra' in migration_galaxy"
-          - "'1.6.0' in migration_galaxy"
+          - "'tailscale_memory_limit: \"0\"' in migration_deploy"
+          - "'tailscale_memory_swap: \"0\"' in migration_deploy"
+          - "'jaxzin.infra' not in migration_galaxy"
         fail_msg: >
           gitea-deploy.yml must include jaxzin.infra.tailscale_sidecar (FQCN,
           never the bare local 'name: tailscale_sidecar'), set
           tailscale_assert_tailnet_route: true and tailscale_dns_watchdog_host_dir
           for the Gitea sidecar, gate the include with
-          'when: tailscale_enabled | bool', and galaxy-requirements.yml must pin
-          jaxzin.infra at 1.6.0 (#128).
+          'when: tailscale_enabled | bool', and un-cap tailscaled by setting BOTH
+          tailscale_memory_limit: "0" and tailscale_memory_swap: "0" (the
+          collection's 96m/192m defaults would newly OOM-cap the sidecar). The
+          collection is now VENDORED playbook-adjacent (DR-self-contained), NOT
+          galaxy-fetched, so jaxzin.infra must NOT appear in
+          galaxy-requirements.yml (#128).
 
     - name: "CHECK 18: Assert the local role is deleted"
       stat:
         path: "{{ roles_dir }}/tailscale_sidecar"
       register: local_sidecar_role_stat
 
-    - name: "CHECK 18: Assert the stale vendored collection copy is deleted"
+    - name: "CHECK 18: Stat the stale root-level vendored collection copy"
       stat:
         path: "{{ project_root }}/collections/ansible_collections/jaxzin/infra"
+      register: old_root_collection_stat
+
+    - name: "CHECK 18: Stat the playbook-adjacent vendored collection"
+      stat:
+        path: "{{ project_root }}/playbooks/collections/ansible_collections/jaxzin/infra/galaxy.yml"
       register: vendored_collection_stat
 
-    - name: "CHECK 18: Assert both retired copies are gone"
+    - name: "CHECK 18: Assert the collection is vendored playbook-adjacent (DR-self-contained)"
       assert:
         that:
           - not local_sidecar_role_stat.stat.exists
-          - not vendored_collection_stat.stat.exists
+          - not old_root_collection_stat.stat.exists
+          - vendored_collection_stat.stat.exists
         fail_msg: >
           The retired local role (playbooks/roles/tailscale_sidecar) and the
-          stale vendored collection copy
-          (collections/ansible_collections/jaxzin/infra) must both be deleted —
-          the sidecar now comes from the pinned jaxzin.infra collection (#128).
+          stale root-level collection copy
+          (collections/ansible_collections/jaxzin/infra) must both be gone, and
+          the jaxzin.infra collection MUST be vendored playbook-adjacent at
+          playbooks/collections/ansible_collections/jaxzin/infra (galaxy.yml
+          present) so the deploy + offline tests resolve the FQCN with no Galaxy
+          fetch (DR-self-contained, #128).
+
+    # ================================================================
+    # Check 19: the vendored tailscale_sidecar keeps the jaxzin.infra#7
+    #           DNS watchdog — downstream 127.0.0.11 resolv.conf heal +
+    #           upstream accept-dns bounce on MagicDNS SERVFAIL. Without
+    #           it a sidecar restart re-breaks Gitea OIDC login (500).
+    # ================================================================
+    - name: "CHECK 19: Read the vendored dns-watchdog.sh"
+      ansible.builtin.slurp:
+        src: "{{ project_root }}/playbooks/collections/ansible_collections/jaxzin/infra/roles/tailscale_sidecar/files/dns-watchdog.sh"
+      register: dns_watchdog_raw
+
+    - name: "CHECK 19: Decode dns-watchdog.sh"
+      ansible.builtin.set_fact:
+        dns_watchdog_sh: "{{ dns_watchdog_raw.content | b64decode }}"
+
+    - name: "CHECK 19: Assert the #7 watchdog (downstream heal + upstream accept-dns bounce) is present"
+      ansible.builtin.assert:
+        that:
+          - "'127.0.0.11' in dns_watchdog_sh"
+          - "'heal_resolv_conf' in dns_watchdog_sh"
+          - "'accept-dns=false' in dns_watchdog_sh"
+          - "'bounce_accept_dns' in dns_watchdog_sh"
+          - "'probe_upstream' in dns_watchdog_sh"
+        fail_msg: >
+          The vendored tailscale_sidecar lost the jaxzin.infra#7 DNS watchdog:
+          dns-watchdog.sh must keep the downstream 127.0.0.11 resolv.conf heal
+          (heal_resolv_conf) AND the upstream watchdog (probe_upstream +
+          bounce_accept_dns / accept-dns=false). Without it a sidecar restart
+          re-breaks Gitea OIDC (500) and gitea-db resolution.
+        success_msg: "jaxzin.infra#7 DNS watchdog present in the vendored role."
 
     # ================================================================
     # Cleanup


### PR DESCRIPTION
## What & why

Builds on #132 (which migrated the Gitea Tailscale sidecar to the `jaxzin.infra.tailscale_sidecar` collection) with three hardening fixes. Each was caught by an adversarial review of the migration and each is already validated in production (see Verification).

### 1. DR-self-contained vendoring (drop the Galaxy fetch)

#132 consumes the collection via `galaxy-requirements.yml` (a network fetch from Ansible Galaxy at deploy time). This PR **vendors `jaxzin.infra` 1.6.0 playbook-adjacent** at `playbooks/collections/ansible_collections/jaxzin/infra/` and removes it from `galaxy-requirements.yml`. The deploy (`dawidd6/action-ansible-playbook`, `directory: ./playbooks`) resolves the FQCN via Ansible's automatic `<playbook_dir>/collections` search — no network dependency at deploy time, no `ansible.cfg` needed. This matches the plan's explicit "re-vendor, not a Galaxy/git fetch (DR-self-contained)" decision and the bootstrap's DR-first principle. (`tafeen.synology` stays galaxy-managed.)

### 2. Un-cap tailscaled memory

#132 sets no memory override, so the sidecar inherits the collection's `96m`/`192m` defaults. The live sidecar was measured **uncapped** (`mem=0 swap=0`); a new 96m cap risks OOM-killing `tailscaled`, and an OOM-kill re-breaks DNS — the exact failure this migration exists to fix. This PR sets `tailscale_memory_limit: "0"` **and** `tailscale_memory_swap: "0"` (Docker "unlimited" must pair memory + swap), preserving today's behavior.

### 3. Restore the role-content regression locks

Because #132 galaxy-fetches, the role wasn't in-repo at test time, so the tailscale role-content checks were dropped. Vendoring brings the role back, so this PR:
- restores **Check B** (`TS_ACCEPT_DNS` wired in the sidecar `env:`), with a **hardened `has_env_var`** that strips comment lines and matches the key form — a comment in the vendored role mentions `TS_ACCEPT_DNS`, which a bare substring match would let pass vacuously;
- adds **CHECK 19** locking the jaxzin.infra#7 watchdog content in `dns-watchdog.sh` (downstream `127.0.0.11` resolv.conf heal + upstream `accept-dns` bounce: `heal_resolv_conf`, `probe_upstream`, `bounce_accept_dns`);
- updates **CHECK 18** to lock the new decision (vendored playbook-adjacent + not in galaxy-requirements + both memory vars `"0"`).

## Verification

- `make test` → **ok=72 failed=0**; `tests/check_docker_tasks.py` → PASSED, 0 errors.
- FQCN resolves in the deploy context (`<playbook_dir>/collections` adjacency) and offline.
- Adversarial proofs that the new locks bite: dropping the real `TS_ACCEPT_DNS` env line (keeping the comment) fails Check B; removing `bounce_accept_dns` fails CHECK 19.
- **Already proven in production:** an equivalent change was deployed to the NAS and the restart-survival test passed — after restarting `tailscale-gitea` + `gitea`, the sidecar self-healed DNS (auth name resolved to authentik's tailnet IP, OIDC returned 307) with **no** manual `accept-dns` bounce. Merging brings `main` in line with what's deployed.

Supersedes #134 (a parallel full-migration branch); #132 landed the migration, this PR adds the hardening on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
