### PR TITLE
fix(gitea-runner): provide become password for Play 2 (fix "Missing sudo password")

### DIFF
--- a/.github/workflows/common-bootstrap.yml
+++ b/.github/workflows/common-bootstrap.yml
@@ -125,6 +125,6 @@ jobs:
             [nas]
             ${{ secrets.NAS_HOST }} ansible_user="${{ secrets.NAS_SSH_USER }}" ansible_become_password="${{ secrets.NAS_SSH_PASSWORD }}"
             [gitea_runner]
-            ${{ secrets.GITEA_RUNNER_HOST }} ansible_user="${{ vars.GITEA_RUNNER_SSH_USER }}" ansible_ssh_private_key_file="~/.ssh/gitea_runner_key" ansible_ssh_common_args="-o StrictHostKeyChecking=accept-new"
+            ${{ secrets.GITEA_RUNNER_HOST }} ansible_user="${{ vars.GITEA_RUNNER_SSH_USER }}" ansible_ssh_private_key_file="~/.ssh/gitea_runner_key" ansible_become_password="${{ secrets.GITEA_RUNNER_SUDO_PASSWORD }}" ansible_ssh_common_args="-o StrictHostKeyChecking=accept-new"
           requirements: galaxy-requirements.yml
           options: ${{ inputs.dry_run && '--check --diff' || '' }}

--- a/docs/runbooks/gitea-runner-host.md
+++ b/docs/runbooks/gitea-runner-host.md
@@ -14,7 +14,10 @@ runner target are **different machines**, connected over SSH.
 ## Target-host contract (the only things assumed)
 
 1. Reachable over **SSH** from the controller, with a sudo-capable user
-   (`GITEA_RUNNER_SSH_USER`) and the `GITEA_RUNNER_SSH_KEY` authorized.
+   (`GITEA_RUNNER_SSH_USER`) and the `GITEA_RUNNER_SSH_KEY` authorized. Play 2
+   runs `become: true` non-interactively, so that user needs either passwordless
+   sudo (NOPASSWD) or its sudo password supplied via the
+   `GITEA_RUNNER_SUDO_PASSWORD` secret.
 2. Reachable **before** it is on the tailnet (the seed joins the tailnet),
    so `GITEA_RUNNER_HOST` must be LAN-resolvable at seed time.
 3. A systemd Linux host where Docker can be installed.
@@ -72,6 +75,7 @@ install the key over the key it installs).
 | `GITEA_RUNNER_HOST` | Secret | The target host (LAN-resolvable for pre-tailnet seeding). |
 | `GITEA_RUNNER_SSH_USER` | Variable | Sudo-capable SSH user on the target. |
 | `GITEA_RUNNER_SSH_KEY` | Secret | Private key authorized on the target. |
+| `GITEA_RUNNER_SUDO_PASSWORD` | Secret | `sudo`/become password for `GITEA_RUNNER_SSH_USER`. Play 2 runs `become: true` non-interactively (`runner_host_seed` installs Docker + joins the tailnet as root), so the password is required unless that user has passwordless sudo (NOPASSWD) — in which case the secret may be left unset. |
 | `TS_AUTHKEY` | Secret | Reused to join the target to the tailnet. |
 | `GITEA_RUNNER_IMAGE` / `_NAME` / `_DATA_PATH` | Variable | Optional overrides (see role defaults). |
 

--- a/tests/test-regression.yml
+++ b/tests/test-regression.yml
@@ -288,11 +288,18 @@
           - "'ansible_ssh_private_key_file' in common_bootstrap"
           - "'ansible_connection=local' not in common_bootstrap"
           - "'connection: local' not in gitea_deploy"
+          # Play 2 (gitea_runner) runs become:true; the runner-host inventory
+          # MUST supply a become password so non-interactive sudo works (the
+          # runner SSH user is key-auth'd but not necessarily passwordless-sudo).
+          # Without it the deploy fails with "Missing sudo password".
+          - "'GITEA_RUNNER_SUDO_PASSWORD' in common_bootstrap"
         fail_msg: >
           The opportunistic SSH wiring regressed: common-bootstrap.yml must
           install GITEA_RUNNER_SSH_KEY and set ansible_ssh_private_key_file
-          for [gitea_runner] (NOT ansible_connection=local), and
-          gitea-deploy.yml Play 2 must NOT be connection: local.
+          for [gitea_runner] (NOT ansible_connection=local), set
+          ansible_become_password from GITEA_RUNNER_SUDO_PASSWORD (Play 2 runs
+          become:true on a non-passwordless-sudo host), and gitea-deploy.yml
+          Play 2 must NOT be connection: local.
 
     - name: "CHECK 8: Assert the host is seeded before the runner is deployed"
       assert:


### PR DESCRIPTION
## What & why

The `Bootstrap` deploy's **Play 2** (`hosts: gitea_runner`, `become: true`) installs Docker + joins the tailnet on `GITEA_RUNNER_HOST` as root, but its inventory line supplied **no become password** (unlike the `[nas]` line, which sets `ansible_become_password` from `NAS_SSH_PASSWORD`). On a runner host whose SSH user isn't passwordless-sudo, Play 2 fails immediately with:

```
fatal: [GITEA_RUNNER_HOST]: FAILED! => {"msg": "Missing sudo password"}
```

(Observed on the 2026-06-18 `main` deploy: Play 1/NAS `ok=70 failed=0`, Play 2/runner `ok=0 failed=1`.)

## Changes

- **`common-bootstrap.yml`** — add `ansible_become_password="${{ secrets.GITEA_RUNNER_SUDO_PASSWORD }}"` to the `[gitea_runner]` inventory line (mirrors the `[nas]` pattern).
- **`tests/test-regression.yml`** — CHECK 8 now asserts `GITEA_RUNNER_SUDO_PASSWORD` is wired (regression-lock so the become password can't be silently dropped, re-breaking the deploy).
- **`docs/runbooks/gitea-runner-host.md`** — document the new secret in the CI-config table + the target-host contract.

## Operator prereq (required for the deploy to pass)

Provision the new secret with the runner user's sudo password:

```
gh secret set GITEA_RUNNER_SUDO_PASSWORD --repo jaxzin/jaxzin-infra-bootstrap
```

…and add `GITEA_RUNNER_SUDO_PASSWORD=<password>` to local `.secrets` (for `act`-based runs). **Leave it unset only if** `GITEA_RUNNER_SSH_USER` has passwordless sudo (NOPASSWD) on the host. After merging + setting the secret, a `main` deploy's Play 2 will complete and the Bootstrap workflow goes fully green.

## Verification

- `make test` → **ok=72 failed=0**; `tests/check_docker_tasks.py` → PASSED.
- Adversarially confirmed CHECK 8 bites: removing the `GITEA_RUNNER_SUDO_PASSWORD` reference from the workflow fails the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
