### PR TITLE
fix(gitea-runner): rely on passwordless sudo for Play 2 (revert #138)

### DIFF
--- a/.github/workflows/common-bootstrap.yml
+++ b/.github/workflows/common-bootstrap.yml
@@ -125,6 +125,6 @@ jobs:
             [nas]
             ${{ secrets.NAS_HOST }} ansible_user="${{ secrets.NAS_SSH_USER }}" ansible_become_password="${{ secrets.NAS_SSH_PASSWORD }}"
             [gitea_runner]
-            ${{ secrets.GITEA_RUNNER_HOST }} ansible_user="${{ vars.GITEA_RUNNER_SSH_USER }}" ansible_ssh_private_key_file="~/.ssh/gitea_runner_key" ansible_become_password="${{ secrets.GITEA_RUNNER_SUDO_PASSWORD }}" ansible_ssh_common_args="-o StrictHostKeyChecking=accept-new"
+            ${{ secrets.GITEA_RUNNER_HOST }} ansible_user="${{ vars.GITEA_RUNNER_SSH_USER }}" ansible_ssh_private_key_file="~/.ssh/gitea_runner_key" ansible_ssh_common_args="-o StrictHostKeyChecking=accept-new"
           requirements: galaxy-requirements.yml
           options: ${{ inputs.dry_run && '--check --diff' || '' }}

--- a/docs/runbooks/gitea-runner-host.md
+++ b/docs/runbooks/gitea-runner-host.md
@@ -13,11 +13,14 @@ runner target are **different machines**, connected over SSH.
 
 ## Target-host contract (the only things assumed)
 
-1. Reachable over **SSH** from the controller, with a sudo-capable user
-   (`GITEA_RUNNER_SSH_USER`) and the `GITEA_RUNNER_SSH_KEY` authorized. Play 2
-   runs `become: true` non-interactively, so that user needs either passwordless
-   sudo (NOPASSWD) or its sudo password supplied via the
-   `GITEA_RUNNER_SUDO_PASSWORD` secret.
+1. Reachable over **SSH** from the controller, with the `GITEA_RUNNER_SSH_KEY`
+   authorized for `GITEA_RUNNER_SSH_USER`, and that user must have
+   **passwordless sudo** (`NOPASSWD`). Play 2 runs `become: true`
+   non-interactively over SSH and supplies **no** sudo password — the Raspberry
+   Pi default `pi` user already has `NOPASSWD: ALL`. (Do NOT wire a become
+   password: feeding one into a NOPASSWD sudo flow makes Ansible fail with
+   "Incorrect sudo password".) Confirm with
+   `sudo -k; sudo -n true && echo PASSWORDLESS-SUDO`.
 2. Reachable **before** it is on the tailnet (the seed joins the tailnet),
    so `GITEA_RUNNER_HOST` must be LAN-resolvable at seed time.
 3. A systemd Linux host where Docker can be installed.
@@ -75,7 +78,6 @@ install the key over the key it installs).
 | `GITEA_RUNNER_HOST` | Secret | The target host (LAN-resolvable for pre-tailnet seeding). |
 | `GITEA_RUNNER_SSH_USER` | Variable | Sudo-capable SSH user on the target. |
 | `GITEA_RUNNER_SSH_KEY` | Secret | Private key authorized on the target. |
-| `GITEA_RUNNER_SUDO_PASSWORD` | Secret | `sudo`/become password for `GITEA_RUNNER_SSH_USER`. Play 2 runs `become: true` non-interactively (`runner_host_seed` installs Docker + joins the tailnet as root), so the password is required unless that user has passwordless sudo (NOPASSWD) — in which case the secret may be left unset. |
 | `TS_AUTHKEY` | Secret | Reused to join the target to the tailnet. |
 | `GITEA_RUNNER_IMAGE` / `_NAME` / `_DATA_PATH` | Variable | Optional overrides (see role defaults). |
 

--- a/tests/test-regression.yml
+++ b/tests/test-regression.yml
@@ -288,18 +288,18 @@
           - "'ansible_ssh_private_key_file' in common_bootstrap"
           - "'ansible_connection=local' not in common_bootstrap"
           - "'connection: local' not in gitea_deploy"
-          # Play 2 (gitea_runner) runs become:true; the runner-host inventory
-          # MUST supply a become password so non-interactive sudo works (the
-          # runner SSH user is key-auth'd but not necessarily passwordless-sudo).
-          # Without it the deploy fails with "Missing sudo password".
-          - "'GITEA_RUNNER_SUDO_PASSWORD' in common_bootstrap"
+          # Play 2 (gitea_runner) runs become:true over SSH; the runner user
+          # must have PASSWORDLESS sudo (NOPASSWD), so the inventory carries no
+          # become password — feeding one into a NOPASSWD sudo flow makes
+          # Ansible fail with "Incorrect sudo password". Lock that the runner
+          # line does not (re)introduce a become password.
+          - "'GITEA_RUNNER_SUDO_PASSWORD' not in common_bootstrap"
         fail_msg: >
           The opportunistic SSH wiring regressed: common-bootstrap.yml must
           install GITEA_RUNNER_SSH_KEY and set ansible_ssh_private_key_file
-          for [gitea_runner] (NOT ansible_connection=local), set
-          ansible_become_password from GITEA_RUNNER_SUDO_PASSWORD (Play 2 runs
-          become:true on a non-passwordless-sudo host), and gitea-deploy.yml
-          Play 2 must NOT be connection: local.
+          for [gitea_runner] (NOT ansible_connection=local), must NOT set a
+          become password for the runner (it relies on passwordless sudo), and
+          gitea-deploy.yml Play 2 must NOT be connection: local.
 
     - name: "CHECK 8: Assert the host is seeded before the runner is deployed"
       assert:
@@ -387,11 +387,17 @@
           - "'GITEA_RUNNER_HOST' in runner_runbook"
           - "'SSH' in runner_runbook"
           - "'swappable' in runner_runbook"
+          # The runner user runs Play 2's become:true with NO sudo password, so
+          # passwordless sudo (NOPASSWD) is a load-bearing, unenforceable host
+          # prereq — it MUST stay documented (feeding a become password into a
+          # NOPASSWD flow makes Ansible fail "Incorrect sudo password").
+          - "'NOPASSWD' in runner_runbook"
           - "'GITEA_RUNNER_HOST' in readme"
         fail_msg: >
           docs/runbooks/gitea-runner-host.md and README.md must document the
           opportunistic target-host contract (reachable over SSH, has Docker,
-          joins the tailnet; host is GITEA_RUNNER_HOST and swappable).
+          joins the tailnet; host is GITEA_RUNNER_HOST and swappable; the
+          runner user has passwordless/NOPASSWD sudo).
 
     # ================================================================
     # Check 9: Gitea sidecar uses tailscale_accept_dns: true so MagicDNS


### PR DESCRIPTION
## What & why

`#138` wired `ansible_become_password` for Play 2 to fix "Missing sudo password" — but `GITEA_RUNNER_HOST` is **davis-bridge** (a Raspberry Pi; SSH user `pi`), and `pi` has **passwordless sudo** (`NOPASSWD`) by default. Feeding a become password into a NOPASSWD sudo flow makes Ansible fail with **"Incorrect sudo password"** (confirmed: two deploys failed that way; `sudo -k; sudo -n true` on the host returns `PASSWORDLESS-SUDO`).

This reverts the become-password approach and relies on the passwordless sudo thats already there — Play 2 `become: true` runs plain `sudo`, which succeeds under NOPASSWD.

## Changes
- `common-bootstrap.yml` — drop `ansible_become_password` from the `[gitea_runner]` inventory line.
- `tests/test-regression.yml` — CHECK 8 now locks that the runner line carries **no** become password (`GITEA_RUNNER_SUDO_PASSWORD not in`) and that the runbook documents the `NOPASSWD` prereq.
- `docs/runbooks/gitea-runner-host.md` — target-host contract now states passwordless sudo (NOPASSWD) as the requirement; removed the `GITEA_RUNNER_SUDO_PASSWORD` secret row.

## Operator
The `GITEA_RUNNER_SUDO_PASSWORD` secret is now unused — delete it (`gh secret delete GITEA_RUNNER_SUDO_PASSWORD`). The runner user just needs NOPASSWD sudo (the Pi default).

## Verification
`make test` -> **ok=72 failed=0**; `check_docker_tasks.py` PASSED. Supersedes the closed #135 (same approach, cleanly rebuilt on current main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
