### PR TITLE
fix(ci): drift alerts via curl, not the arm64-incompatible Discord action

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -145,18 +145,24 @@ jobs:
             *) echo "plan errored (exit ${ec})" ;;
           esac
 
+      # curl, not the Docker-based Ilshidur/action-discord: that action has no arm64
+      # image, so GitHub Actions building it on this self-hosted ARM runner fails with
+      # "exec format error" and orphans an intermediate container every run. curl ships
+      # in the runner image and is architecture-independent.
       - name: Notify Discord on drift
         if: steps.plan.outputs.exitcode == '2'
-        uses: Ilshidur/action-discord@0.3.2
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        with:
-          args: ":warning: tofu/network drift detected. Investigate the workflow run for details."
+        run: |
+          curl -fsS -X POST -H 'Content-Type: application/json' \
+            -d '{"content": ":warning: tofu/network drift detected. Investigate the workflow run for details."}' \
+            "$DISCORD_WEBHOOK"
 
       - name: Notify Discord on plan error
         if: steps.plan.outputs.exitcode != '0' && steps.plan.outputs.exitcode != '2'
-        uses: Ilshidur/action-discord@0.3.2
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        with:
-          args: ":octagonal_sign: tofu/network drift check errored. Investigate the workflow run for details."
+        run: |
+          curl -fsS -X POST -H 'Content-Type: application/json' \
+            -d '{"content": ":octagonal_sign: tofu/network drift check errored. Investigate the workflow run for details."}' \
+            "$DISCORD_WEBHOOK"


### PR DESCRIPTION
## Problem
The daily **Infrastructure Health Check** orphans ~3 exited containers per run on `davis-bridge` (20+ piled up). Root cause confirmed from the failed run log:

```
Step 3/6 : RUN npm ci --production
exec /bin/sh: exec format error
The command '/bin/sh -c npm ci --production' returned a non-zero code: 1
```

The `tofu-network-drift` job runs on the **self-hosted ARM (aarch64) runner**. `Ilshidur/action-discord` is a Docker-based action with **no arm64 image**, so GitHub Actions building it on this runner dies with `exec format error`, retries 3x, and abandons an intermediate container each time. `npm ci` is just where it dies — it is an architecture mismatch, not an npm problem.

## Fix
Replace the **two self-hosted** notify steps (drift + plan-error) with a direct `curl` POST to the webhook. `curl` ships in the `jaxzin-infra-runner` image and is architecture-independent. The **two `ubuntu-latest` (amd64) Discord notifications are unchanged** — the action builds fine there.

## Verification
- `yaml.safe_load` parses the result.
- Confirmed `curl` (and `python3`, `node`, `wget`) are present in `ghcr.io/jaxzin/jaxzin-infra-runner:latest`.
- Diff is limited to the two self-hosted steps.
- Definitive confirmation: the next scheduled run should produce **no** orphaned `npm ci` container.

## Not included (separate issues)
- The `tofu plan` apparently errors daily (that’s why the notify path fires) — worth its own look.
- The `health-check / bootstrap` job fails on an Ansible undefined variable (`gitea-deploy.yml`, "Expose the runner registration token to Play 2"). Separate root cause.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>