### PR TITLE
fix(ci): guard runner-token expose so the dry-run health check passes

### DIFF
--- a/playbooks/gitea-deploy.yml
+++ b/playbooks/gitea-deploy.yml
@@ -152,7 +152,13 @@
     - name: Expose the runner registration token to Play 2
       set_fact:
         gitea_runner_registration_token: "{{ runner_reg_token_result.json.token }}"
-      when: not (lookup('ansible.builtin.env', 'GITEA_ACTIONS', default='') == 'true')
+      when:
+        # Dry-run/check mode skips the mint task above, so runner_reg_token_result
+        # has no `.json` — guard exactly like the tailnet-IP task below so the
+        # health check doesn't fail on an absent token (Play 2 already defaults
+        # gitea_runner_token to '' when this fact is unset).
+        - not (lookup('ansible.builtin.env', 'GITEA_ACTIONS', default='') == 'true')
+        - runner_reg_token_result.json.token | default('') | length > 0
 
     # Capture Gitea's TAILNET IP from its sidecar so Play 2 can pin
     # gitea.<tailnet> -> this IP in the runner container's /etc/hosts. This


### PR DESCRIPTION
## Problem
The daily **Infrastructure Health Check** (dry-run) fails the `health-check / bootstrap` job:
```
fatal: FAILED! => "The task includes an option with an undefined variable.. 'dict object' has no attribute 'json'"
playbooks/gitea-deploy.yml ... "Expose the runner registration token to Play 2"
```
## Root cause
In dry-run/check mode the preceding `uri` task **"Mint Gitea runner registration token"** is skipped, so `runner_reg_token_result` has no `.json`. The expose task referenced `runner_reg_token_result.json.token` **unconditionally**.
## Fix
Add the same guard the neighboring **"Expose the Gitea tailnet IP to Play 2"** task already uses (`... | default('') | length > 0`). Real deploys are unchanged; Play 2 already defaults `gitea_runner_token` to `''`.

Note: this and #141 are the two failing jobs in the daily run; with both merged the health check should go green (modulo whatever the now-reachable `tofu plan` reports).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>