### PR TITLE
fix(ci): give the gitea_runner inventory host a become password

### DIFF
--- a/.github/workflows/common-bootstrap.yml
+++ b/.github/workflows/common-bootstrap.yml
@@ -125,6 +125,6 @@ jobs:
             [nas]
             ${{ secrets.NAS_HOST }} ansible_user="${{ secrets.NAS_SSH_USER }}" ansible_become_password="${{ secrets.NAS_SSH_PASSWORD }}"
             [gitea_runner]
-            ${{ secrets.GITEA_RUNNER_HOST }} ansible_user="${{ vars.GITEA_RUNNER_SSH_USER }}" ansible_ssh_private_key_file="~/.ssh/gitea_runner_key" ansible_ssh_common_args="-o StrictHostKeyChecking=accept-new"
+            ${{ secrets.GITEA_RUNNER_HOST }} ansible_user="${{ vars.GITEA_RUNNER_SSH_USER }}" ansible_become_password="${{ secrets.GITEA_RUNNER_SUDO_PASSWORD }}" ansible_ssh_private_key_file="~/.ssh/gitea_runner_key" ansible_ssh_common_args="-o StrictHostKeyChecking=accept-new"
           requirements: galaxy-requirements.yml
           options: ${{ inputs.dry_run && '--check --diff' || '' }}


### PR DESCRIPTION
Play 2 fails at `Gathering Facts` with `Missing sudo password` because the `[gitea_runner]` inventory host had no `ansible_become_password` (unlike `[nas]`). Wires in the existing **GITEA_RUNNER_SUDO_PASSWORD** secret. Third and (hopefully) final layer of the daily-health-check failure chain, after #141 and #142.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>