### PR TITLE
fix(gitea-deploy): make cm_config parse + reconcile watchdog deploy-safe

### DIFF
--- a/playbooks/roles/container_manager_config/tasks/main.yml
+++ b/playbooks/roles/container_manager_config/tasks/main.yml
@@ -35,9 +35,18 @@
   block:
     - name: Parse current dockerd config (empty object if absent)
       ansible.builtin.set_fact:
+        # ansible-core 2.19 Jinja native types coerce a decoded JSON *object*
+        # into a dict (a JSON object like {"log-driver":"json-file"} is also a
+        # valid Python literal), so cm_config_current_text may ALREADY be a
+        # mapping — `from_json` on it then raises "the JSON object must be str,
+        # bytes or bytearray, not dict". Handle both shapes: use it directly
+        # when it's already a mapping; only from_json a non-empty string;
+        # empty/absent → {}. (`| string` guards trim against a native dict.)
         cm_config_current: >-
-          {{ (cm_config_current_text | from_json)
-             if (cm_config_current_text | trim != '') else {} }}
+          {{ cm_config_current_text
+             if (cm_config_current_text is mapping)
+             else ((cm_config_current_text | from_json)
+                   if (cm_config_current_text | string | trim != '') else {}) }}
         cm_config_parse_ok: true
   rescue:
     - name: Treat malformed dockerd.json as empty and flag it (do NOT abort)

--- a/playbooks/roles/stack_reconcile/tasks/main.yml
+++ b/playbooks/roles/stack_reconcile/tasks/main.yml
@@ -60,6 +60,16 @@
   # for the webhook, then execs the reconcile script — so the cron line stays
   # secret-free.
 
+- name: Ensure the stack-reconcile watchdog image is present
+  # docker_container cannot create a NOT-YET-EXISTING container in --check mode
+  # when the image is absent locally ("Cannot create container when image is
+  # not specified!"). Pull the image explicitly, and run it even in check mode
+  # (check_mode: false) so a dry-run can still validate the container task.
+  # Pulling an image is non-disruptive — it does not touch running containers.
+  community.docker.docker_image_pull:
+    name: "{{ stack_reconcile_image }}"
+  check_mode: false
+
 - name: Deploy stack-reconcile watchdog container
   community.docker.docker_container:
     name: "{{ stack_reconcile_container_name }}"


### PR DESCRIPTION
Follow-up to #144. The health-check **dry-run** (`--check`) against the live NAS caught two deploy-blockers that offline tests can't see:

1. **container_manager_config** — ansible-core 2.19 native types coerce a decoded JSON *object* into a dict, so `from_json` threw against the real `dockerd.json`; the rescue then mislabeled the valid file 'malformed' and **skipped applying live-restore**. Parse now uses the value directly when it's already a mapping. Verified on ansible-core 2.19.0 (dict/json-string/empty).
2. **stack_reconcile** — `docker_container` can't create the not-yet-existing watchdog in `--check` mode with an un-pulled image. Pre-pull via `docker_image_pull` with `check_mode: false` (non-disruptive) so dry-runs validate it.

Found by the dry-run pre-flight before any real apply. Next: re-run the dry-run to confirm green, then real deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)