### PR TITLE
fix(certbot): source Discord webhook from a 0600 env-file, not a world-readable script

### DIFF
--- a/playbooks/roles/certbot/tasks/main.yml
+++ b/playbooks/roles/certbot/tasks/main.yml
@@ -41,6 +41,20 @@
     owner: root
     group: root
     mode: '0600'
+  no_log: true # embeds the DNSimple OAuth token — keep it out of the logs
+
+# The Discord webhook is a credential: it lives in its own 0600 root env-file,
+# sourced at runtime by renew-cert.sh, and is NEVER templated into that
+# world-readable script. Same secure pattern as gitea_backup's
+# b2_credentials.env / gitea_oidc_reconcile.env.
+- name: Create secure Discord webhook env file
+  template:
+    src: discord_webhook.env.j2
+    dest: "{{ certbot_data_path }}/discord_webhook.env"
+    owner: root
+    group: root
+    mode: '0600'
+  no_log: true # holds the Discord webhook credential
 
 - name: Template the renew-cert script
   template:
@@ -48,7 +62,9 @@
     dest: "{{ certbot_data_path }}/scripts/renew-cert.sh"
     owner: root
     group: root
-    mode: '0755'
+    # 0750: only root runs this (cron + the initial-acquisition command
+    # below). It holds no credential anymore, so it need not be world-readable.
+    mode: '0750'
 
 - name: Run initial certificate acquisition
   command: "{{ certbot_data_path }}/scripts/renew-cert.sh"

--- a/playbooks/roles/certbot/templates/discord_webhook.env.j2
+++ b/playbooks/roles/certbot/templates/discord_webhook.env.j2
@@ -1,0 +1,5 @@
+# Provisioned by the certbot role (Ansible template, no_log, root 0600).
+# Sourced at runtime by renew-cert.sh so the Discord webhook credential is
+# NEVER templated into that world-readable script. Optional: an empty/absent
+# value makes the renewal notifications a no-op — it never breaks cert renewal.
+DISCORD_WEBHOOK="{{ discord_webhook }}"

--- a/playbooks/roles/certbot/templates/renew-cert.sh.j2
+++ b/playbooks/roles/certbot/templates/renew-cert.sh.j2
@@ -2,6 +2,12 @@
 set -e
 source {{ certbot_data_path }}/dnsimple_env.sh
 
+# Discord webhook is a credential — sourced at runtime from its own 0600 root
+# env-file, never inlined into this (world-readable) script. Optional: if the
+# file is absent or DISCORD_WEBHOOK is empty, notifications simply no-op.
+DISCORD_WEBHOOK_ENV="{{ certbot_data_path }}/discord_webhook.env"
+[ -f "${DISCORD_WEBHOOK_ENV}" ] && source "${DISCORD_WEBHOOK_ENV}"
+
 CERT_DIR="{{ certbot_data_path }}/certs"
 LIVE_DIR="${CERT_DIR}/live/{{ certbot_domain }}"
 FULLCHAIN_PATH="${LIVE_DIR}/fullchain.pem"
@@ -14,9 +20,9 @@ send_notification() {
   echo "$(date '+%Y-%m-%d %H:%M:%S') [Certbot] ${subject}: ${message}"
   # Use Synology's native notification system
   /usr/syno/bin/synoservicectl --notify "${subject}" "${message}"
-  # If you prefer Discord, uncomment and configure the following:
-  if [ -n "{{ discord_webhook }}" ]; then
-    curl -H "Content-Type: application/json" -X POST -d "{\"username\": \"Certbot Alert\", \"content\": \"${subject}: ${message}\"}" "{{ discord_webhook }}"
+  # Also post to Discord when a webhook is configured (sourced above).
+  if [ -n "${DISCORD_WEBHOOK}" ]; then
+    curl -H "Content-Type: application/json" -X POST -d "{\"username\": \"Certbot Alert\", \"content\": \"${subject}: ${message}\"}" "${DISCORD_WEBHOOK}"
   fi
 }
 

--- a/tests/test-regression.yml
+++ b/tests/test-regression.yml
@@ -623,6 +623,73 @@
           resolution (2026-06-05 incident).
 
     # ================================================================
+    # Check 16: certbot never inlines the Discord webhook credential into
+    #           the world-readable renew-cert.sh; it sources it from a
+    #           0600 root no_log env-file at runtime.
+    # ================================================================
+    # Templating the webhook variable directly into renew-cert.sh (rendered
+    # 0750, previously 0755) put the credential in cleartext in an on-disk
+    # script readable by any local user. The secure pattern (mirrors
+    # gitea_backup's b2_credentials.env / gitea_oidc_reconcile.env): the value
+    # renders ONLY into discord_webhook.env (root 0600, template no_log), and
+    # the script sources it and uses $DISCORD_WEBHOOK by name. We render BOTH
+    # templates with a sentinel secret and assert where it does (env-file) and
+    # does not (script) land — the render-and-inspect style of CHECK 3/4/7, so
+    # a coincidental substring (the env-FILE name) can't mask a re-inlined value.
+    - name: "CHECK 16: Render renew-cert.sh.j2 with a sentinel webhook secret"
+      template:
+        src: "{{ roles_dir }}/certbot/templates/renew-cert.sh.j2"
+        dest: /tmp/test-renew-cert-rendered.sh
+      vars:
+        certbot_data_path: /tmp/certbot-test
+        certbot_domain: nas.test-tailnet.ts.net
+        certbot_email: test@example.com
+        dsm_cert_name: test-cert
+        discord_webhook: "SENTINEL_DISCORD_WEBHOOK_DO_NOT_INLINE"
+
+    - name: "CHECK 16: Render discord_webhook.env.j2 with the same sentinel"
+      template:
+        src: "{{ roles_dir }}/certbot/templates/discord_webhook.env.j2"
+        dest: /tmp/test-discord-webhook-env-rendered
+      vars:
+        discord_webhook: "SENTINEL_DISCORD_WEBHOOK_DO_NOT_INLINE"
+
+    - name: "CHECK 16: Read the rendered artifacts + certbot tasks"
+      slurp:
+        src: "{{ item }}"
+      register: certbot_webhook_raw
+      loop:
+        - /tmp/test-renew-cert-rendered.sh
+        - /tmp/test-discord-webhook-env-rendered
+        - "{{ roles_dir }}/certbot/tasks/main.yml"
+
+    - name: "CHECK 16: Decode the rendered artifacts + certbot tasks"
+      set_fact:
+        certbot_rendered_script: "{{ certbot_webhook_raw.results[0].content | b64decode }}"
+        certbot_rendered_env: "{{ certbot_webhook_raw.results[1].content | b64decode }}"
+        certbot_tasks: "{{ certbot_webhook_raw.results[2].content | b64decode }}"
+
+    - name: "CHECK 16: Assert the webhook secret is never inlined into the script"
+      assert:
+        that:
+          # The secret value lands ONLY in the 0600 env-file, never the script.
+          - "'SENTINEL_DISCORD_WEBHOOK_DO_NOT_INLINE' not in certbot_rendered_script"
+          - "'SENTINEL_DISCORD_WEBHOOK_DO_NOT_INLINE' in certbot_rendered_env"
+          # The script still sources the env-file and uses the value by name.
+          - "'discord_webhook.env' in certbot_rendered_script"
+          - "'DISCORD_WEBHOOK' in certbot_rendered_script"
+          # The env-file is provisioned securely: template + root 0600 + no_log.
+          - "'discord_webhook.env.j2' in certbot_tasks"
+          - "\"mode: '0600'\" in certbot_tasks"
+          - "'no_log: true' in certbot_tasks"
+        fail_msg: >
+          certbot must NOT template the Discord webhook into the world-readable
+          renew-cert.sh (the sentinel secret leaked into the rendered script).
+          The credential must render only into discord_webhook.env (root 0600,
+          template no_log: true); renew-cert.sh must source that file and use
+          $DISCORD_WEBHOOK by name at runtime.
+
+    # ================================================================
     # Cleanup
     # ================================================================
     - name: Clean up rendered test files
@@ -633,3 +700,5 @@
         - /tmp/test-app-ini-rendered
         - /tmp/test-ts-serve-rendered.json
         - /tmp/test-gitea-runner-config.yml
+        - /tmp/test-renew-cert-rendered.sh
+        - /tmp/test-discord-webhook-env-rendered


### PR DESCRIPTION
## Problem

`playbooks/roles/certbot/templates/renew-cert.sh.j2` templated `{{ discord_webhook }}` **literally** into the rendered `renew-cert.sh`, and `certbot/tasks/main.yml` writes that script `mode: '0755'` (world-readable) with no `no_log`. The Discord webhook token therefore sat in **cleartext on disk, readable by any local user** on the NAS — and also **leaked into Ansible/CI logs** (no `no_log` on the templating task).

Surfaced during the 2026-06-30 gitea-stack-reconcile security review as a pre-existing MAJOR: the reconcile work had already fixed this class for its own webhook via the secure env-file pattern, but the same insecure precedent remained in `certbot`.

## Fix

Adopt the repo's established secure-env-file pattern (`gitea_backup`'s `b2_credentials.env` / `gitea_oidc_reconcile.env`):

- **New** `discord_webhook.env.j2` → the **only** place the secret renders.
- **New task** writes it to `{{ certbot_data_path }}/discord_webhook.env` — `0600` root, `no_log: true`.
- **`renew-cert.sh.j2`** now `source`s that file at runtime (guarded/optional so an absent webhook never aborts renewal) and uses `${DISCORD_WEBHOOK}` by name. No credential in the script.
- **Script mode `0755` → `0750`** — only root runs it (cron + the initial-acquisition command), and it no longer holds a secret.

## Boy Scout

- Added `no_log: true` to the pre-existing **DNSimple-token** task (`dnsimple_env.sh`) — same log-exposure class, was missing it.

## Regression lock-in

- **CHECK 16** in `tests/test-regression.yml` renders *both* templates with a sentinel secret and asserts the value lands **only** in the `0600` env-file, never in the rendered script (render-and-inspect style of CHECK 3/4/7, so the sibling env-*file* name can't mask a re-inlined value).

## Verification

- `grep -rn '{{ discord_webhook }}' playbooks/roles/certbot/` → renders **only** into `discord_webhook.env.j2`.
- `python3 tests/check_docker_tasks.py` → **PASSED, 0 errors**.
- `ansible-playbook tests/test-regression.yml` → **ok=68, failed=0** (CHECK 16 green).
- **Lock-in proven to bite:** temporarily re-inlining the webhook flipped CHECK 16 to `failed=1` on exactly `'SENTINEL…' not in certbot_rendered_script → false`; reverted.
- `bash -n` on the rendered script → syntax OK; the `[ -f "$f" ] && source "$f"` guard reaches end-of-script under `set -e` when the file is absent (optional webhook never aborts renewal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
