### PR TITLE
fix(gitea): bump gitea-db memory limit 384m → 512m (#27)

### DIFF
--- a/playbooks/roles/gitea_server/tasks/main.yml
+++ b/playbooks/roles/gitea_server/tasks/main.yml
@@ -57,8 +57,8 @@
     log_options:
       max-size: "10m"
       max-file: "3"
-    memory: "384m"
-    memory_swap: "768m"
+    memory: "512m"
+    memory_swap: "1024m"
     networks:
       - name: "{{ gitea_network_name }}"
     env:


### PR DESCRIPTION
## What

Salvages one commit that existed **only on the Gitea `origin/main`** and was missing from github `main` (the source of truth): the gitea-db container memory bump `384m → 512m` (swap `768m → 1024m`), originally authored as `4b8f34d0` (#27). This PR **cherry-picks that original commit** (authorship preserved) onto current github main.

## Why this was stranded

While reconciling for an unrelated PR (#146) we found the Gitea `origin/main` had **diverged** from github main: it carried 3 ops commits made directly on Gitea, off a shared fork point (`3fa90978`, #94), while github main evolved separately. Reconciling github → Gitea (the normal one-way mirror direction) would overwrite Gitea main and **lose** anything Gitea-only. This PR moves the one net-meaningful Gitea-only change back onto github main first, so the reconciliation is lossless.

## Net Gitea-only delta = exactly this

Diffing the fork point (`3fa90978`) to Gitea `origin/main` shows a **single** net change — these two lines in `playbooks/roles/gitea_server/tasks/main.yml` (the `gitea-db` container):

```
-    memory: "384m"
-    memory_swap: "768m"
+    memory: "512m"
+    memory_swap: "1024m"
```

The other two Gitea-only commits — `b4002573` ("post drift alerts via curl, not the arm64-incompatible Discord action") and its revert `90f11d23` — **cancel to zero** (add-then-revert of the same `health-check.yml` hunk), so there is nothing to salvage there. If that drift-alert change is actually wanted on github, it's a separate decision — flag it and I'll open a distinct PR.

## Verification

- github main currently has the old value (`memory: "384m"` / `memory_swap: "768m"`) — the bump is genuinely absent, not a no-op.
- Cherry-pick applied cleanly onto the current github main tip.
- No other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
