### PR TITLE
fix(stack-reconcile): restart gitea when a sidecar restart strands it in a dead netns (#148)

### DIFF
--- a/docs/runbooks/gitea-stack-reconcile.md
+++ b/docs/runbooks/gitea-stack-reconcile.md
@@ -88,6 +88,23 @@ Each pass does, in order:
    a missing DB. It keys on `unhealthy` specifically (not merely "not healthy")
    so a container still in its healthcheck `start_period` is left alone — a
    restart there would reset `start_period` and thrash `gitea` every loop.
+5. **Netns reconcile (the 2026-07-05 stranded-namespace incident, #148).**
+   `gitea` shares the sidecar's network namespace
+   (`network_mode: container:tailscale-gitea`). When the sidecar **restarts**
+   (e.g. autoheal acting on a failed healthcheck), Docker creates a **new**
+   namespace for it, but gitea's process stays pinned in the **old** one:
+   `tailscale serve → 127.0.0.1:3000` gets connection refused (external 502)
+   while gitea reports **healthy** forever — its healthcheck runs inside the
+   stranded namespace, where localhost still answers. Nothing else can catch
+   this (both containers are running + healthy by every Docker signal), so the
+   reconcile compares start times: if the child (`stack_reconcile_netns_child`,
+   `gitea`) **started before** the parent (`stack_reconcile_netns_parent`,
+   `tailscale-gitea`), the child is restarted so it rejoins the live namespace.
+   Guards: both running; parent healthy (or has no healthcheck); parent up at
+   least the debounce window, so a flapping sidecar (the 2026-07-05 autoheal
+   restart-loop) gets time to prove stable before the child commits to its
+   namespace. The restart makes the child newer than the parent, so the step is
+   naturally idempotent — one restart per parent restart, never a loop.
 
 The script always exits 0 (best-effort; a reconcile error must never cascade
 into the DR-first Gitea stack). Corrective actions (`docker start` / `docker
@@ -214,6 +231,19 @@ on the NAS:
 If the tailscale sidecar is also down, start it first
 (`/usr/local/bin/docker start tailscale-gitea`) so `gitea` has its network
 namespace, then proceed as above.
+
+**Stranded-namespace variant (external 502 while every container shows
+`Up (healthy)`):** the sidecar was restarted after gitea joined its namespace,
+so gitea is serving into a dead netns. Confirm with
+`/usr/local/bin/docker exec tailscale-gitea wget -q -O- http://127.0.0.1:3000/`
+(connection refused = stranded), wait for `tailscale-gitea` to be stable and
+healthy, then:
+
+```sh
+/usr/local/bin/docker restart gitea
+```
+
+Reconcile's netns step (step 5 above) automates exactly this.
 
 ## Related
 

--- a/playbooks/roles/stack_reconcile/defaults/main.yml
+++ b/playbooks/roles/stack_reconcile/defaults/main.yml
@@ -66,6 +66,14 @@ stack_reconcile_containers: "tailscale-gitea gitea-db gitea"
 stack_reconcile_gate: "gitea"
 stack_reconcile_gate_depends_on: "gitea-db"
 
+# netns reconcile (#148): gitea shares the sidecar's network namespace
+# (network_mode: container:tailscale-gitea). A sidecar restart creates a NEW
+# netns while gitea stays pinned in the OLD one — dead to the world (502) yet
+# reporting healthy. When the child's StartedAt predates a stable, healthy
+# parent's, reconcile restarts the child so it rejoins the live netns.
+stack_reconcile_netns_parent: "tailscale-gitea"
+stack_reconcile_netns_child: "gitea"
+
 stack_reconcile_interval_seconds: 30        # watchdog container loop cadence
 stack_reconcile_debounce_seconds: 90        # ignore stops younger than this
 stack_reconcile_log_max_bytes: 1048576      # trim RECONCILE_LOG past 1 MiB

--- a/playbooks/roles/stack_reconcile/meta/main.yml
+++ b/playbooks/roles/stack_reconcile/meta/main.yml
@@ -135,6 +135,19 @@ argument_specs:
         description: >-
           The gate's dependency that must be healthy first. Default in
           defaults/main.yml.
+      stack_reconcile_netns_parent:
+        type: "str"
+        description: >-
+          Container providing the shared network namespace (the tailscale
+          sidecar). When it restarts, the netns child is stranded in the dead
+          namespace (#148); reconcile restarts the child once the parent is
+          stable. Default in defaults/main.yml.
+      stack_reconcile_netns_child:
+        type: "str"
+        description: >-
+          Container running with network_mode: container:<netns_parent>.
+          Restarted when its StartedAt predates a stable, healthy parent's.
+          Default in defaults/main.yml.
       stack_reconcile_interval_seconds:
         type: "int"
         description: >-

--- a/playbooks/roles/stack_reconcile/tasks/main.yml
+++ b/playbooks/roles/stack_reconcile/tasks/main.yml
@@ -92,6 +92,8 @@
       RECONCILE_CONTAINERS: "{{ stack_reconcile_containers }}"
       RECONCILE_GATE: "{{ stack_reconcile_gate }}"
       RECONCILE_GATE_DEPENDS_ON: "{{ stack_reconcile_gate_depends_on }}"
+      RECONCILE_NETNS_PARENT: "{{ stack_reconcile_netns_parent }}"
+      RECONCILE_NETNS_CHILD: "{{ stack_reconcile_netns_child }}"
       RECONCILE_LOCK: "{{ stack_reconcile_lock_path }}"
       RECONCILE_DEBOUNCE: "{{ stack_reconcile_debounce_seconds | string }}"
       RECONCILE_LOG: "{{ stack_reconcile_log_path }}"

--- a/playbooks/roles/stack_reconcile/templates/stack_reconcile.sh.j2
+++ b/playbooks/roles/stack_reconcile/templates/stack_reconcile.sh.j2
@@ -16,6 +16,8 @@ GATE_DEP="${RECONCILE_GATE_DEPENDS_ON:-}"
 LOCK="${RECONCILE_LOCK:?set RECONCILE_LOCK}"
 DEBOUNCE="${RECONCILE_DEBOUNCE:-90}"
 ENSURE="${RECONCILE_ENSURE_CONTAINER:-}"
+NETNS_PARENT="${RECONCILE_NETNS_PARENT:-}"
+NETNS_CHILD="${RECONCILE_NETNS_CHILD:-}"
 LOG="${RECONCILE_LOG:-/dev/stderr}"
 HOOK="${RECONCILE_DISCORD_WEBHOOK:-}"
 DRYRUN="${RECONCILE_DRYRUN:-0}"
@@ -50,6 +52,17 @@ finished_epoch() {
   # GNU date (Synology host cron) accepts -d <rfc3339> directly.
   date -u -d "$d" +%s 2>/dev/null && return
   # busybox date (Alpine watchdog) needs an explicit input format via -D.
+  date -u -D '%Y-%m-%dT%H:%M:%SZ' -d "$d" +%s 2>/dev/null && return
+  echo ""
+}
+
+# epoch of a docker StartedAt RFC3339Nano string; empty on parse failure.
+# Same dual GNU/busybox `date` dance as finished_epoch above.
+started_epoch() {
+  sa="$(inspect '{{ "{{.State.StartedAt}}" }}' "$1")"
+  case "$sa" in ''|0001-01-01*) echo ""; return;; esac
+  d="$(printf '%s' "$sa" | sed 's/\.[0-9]*Z$/Z/')"
+  date -u -d "$d" +%s 2>/dev/null && return
   date -u -D '%Y-%m-%dT%H:%M:%SZ' -d "$d" +%s 2>/dev/null && return
   echo ""
 }
@@ -127,6 +140,46 @@ if [ -n "$GATE" ] && [ -n "$GATE_DEP" ]; then
     if [ "$DRYRUN" = "1" ]; then log "DRYRUN would restart gate '$GATE'";
     elif $DOCKER restart "$GATE" >/dev/null 2>&1; then alert "restarted '$GATE' (dep '$GATE_DEP' healthy, gate was '$gate_h')";
     else log "FAILED to restart gate '$GATE'"; fi
+  fi
+fi
+
+# --- 4. netns reconcile: a parent restart strands netns-sharing children ----
+# gitea runs with network_mode: container:tailscale-gitea. A restart of the
+# sidecar creates a NEW network namespace, but gitea's process stays pinned in
+# the OLD one — tailscale serve dials 127.0.0.1:3000 in the new netns and gets
+# connection refused (502) while gitea reports HEALTHY forever (its healthcheck
+# runs inside the stranded netns, where localhost still answers). See #148.
+# Remedy: when the child STARTED BEFORE the parent, restart the child so it
+# rejoins the parent's current netns. Guards, in order:
+#   * both running (step 2 above revives stopped ones first);
+#   * parent healthy — or has no healthcheck at all (empty Health). While the
+#     parent is flapping/unhealthy (the 2026-07-05 autoheal loop), restarting
+#     the child would just thrash it into another doomed netns;
+#   * parent up >= DEBOUNCE, so a mid-flap parent gets time to prove stable;
+#   * child StartedAt < parent StartedAt — restart makes child newer, so this
+#     is naturally idempotent (one restart per parent restart, no loop).
+if [ -n "$NETNS_PARENT" ] && [ -n "$NETNS_CHILD" ]; then
+  p_st="$(inspect '{{ "{{.State.Status}}" }}' "$NETNS_PARENT")"
+  c_st="$(inspect '{{ "{{.State.Status}}" }}' "$NETNS_CHILD")"
+  if [ "$p_st" = "running" ] && [ "$c_st" = "running" ]; then
+    p_h="$(inspect '{{ "{{if .State.Health}}{{.State.Health.Status}}{{end}}" }}' "$NETNS_PARENT")"
+    if [ -z "$p_h" ] || [ "$p_h" = "healthy" ]; then
+      p_up="$(started_epoch "$NETNS_PARENT")"
+      c_up="$(started_epoch "$NETNS_CHILD")"
+      if [ -z "$p_up" ] || [ -z "$c_up" ]; then
+        # Unlike the step-2 age-unknown branch (where an orphan left dead is
+        # worse than a start), a restart here is NOT safe to guess: without
+        # both timestamps we cannot tell stranded from fine, and restarting a
+        # fine child is an outage. Skip and log.
+        log "netns: StartedAt unknown for '$NETNS_PARENT' or '$NETNS_CHILD' — skipping"
+      elif [ $(( now - p_up )) -lt "$DEBOUNCE" ]; then
+        log "netns: parent '$NETNS_PARENT' up $(( now - p_up ))s < debounce ${DEBOUNCE}s — wait"
+      elif [ "$c_up" -lt "$p_up" ]; then
+        if [ "$DRYRUN" = "1" ]; then log "DRYRUN would restart netns child '$NETNS_CHILD'";
+        elif $DOCKER restart "$NETNS_CHILD" >/dev/null 2>&1; then alert "restarted '$NETNS_CHILD' (stranded in dead netns: parent '$NETNS_PARENT' restarted after it)";
+        else log "FAILED to restart netns child '$NETNS_CHILD'"; fi
+      fi
+    fi
   fi
 fi
 exit 0

--- a/playbooks/roles/stack_reconcile/templates/stack_reconcile_cron.sh.j2
+++ b/playbooks/roles/stack_reconcile/templates/stack_reconcile_cron.sh.j2
@@ -16,12 +16,15 @@ DOCKER_BIN='{{ stack_reconcile_docker_bin }}'
 RECONCILE_CONTAINERS='{{ stack_reconcile_containers }}'
 RECONCILE_GATE='{{ stack_reconcile_gate }}'
 RECONCILE_GATE_DEPENDS_ON='{{ stack_reconcile_gate_depends_on }}'
+RECONCILE_NETNS_PARENT='{{ stack_reconcile_netns_parent }}'
+RECONCILE_NETNS_CHILD='{{ stack_reconcile_netns_child }}'
 RECONCILE_LOCK='{{ stack_reconcile_lock_path }}'
 RECONCILE_DEBOUNCE='{{ stack_reconcile_debounce_seconds }}'
 RECONCILE_ENSURE_CONTAINER='{{ stack_reconcile_container_name }}'
 RECONCILE_LOG='{{ stack_reconcile_log_path }}'
 RECONCILE_LOG_MAX_BYTES='{{ stack_reconcile_log_max_bytes }}'
 export DOCKER_BIN RECONCILE_CONTAINERS RECONCILE_GATE RECONCILE_GATE_DEPENDS_ON \
+       RECONCILE_NETNS_PARENT RECONCILE_NETNS_CHILD \
        RECONCILE_LOCK RECONCILE_DEBOUNCE RECONCILE_ENSURE_CONTAINER RECONCILE_LOG \
        RECONCILE_LOG_MAX_BYTES
 

--- a/tests/check_docker_tasks.py
+++ b/tests/check_docker_tasks.py
@@ -34,6 +34,14 @@ Checks:
      docker live-restore is on, AND the two lock-path defaults (one in
      stack_reconcile, one in gitea_backup) reduce to the SAME path — a
      single source of truth that a one-sided edit must not be able to split.
+  M) the netns reconcile (#148) is plumbed END-TO-END: the reconcile script
+     implements the stranded-namespace step (RECONCILE_NETNS_PARENT/CHILD +
+     a .State.StartedAt comparison), and BOTH drivers deliver the env — the
+     watchdog container's env: block and the cron wrapper (set + export).
+     A sidecar restart strands gitea in a dead netns while everything
+     reports healthy; only this step catches it, and env lost in either
+     driver disables it silently. (Behavior is locked separately by
+     tests/reconcile_selftest.sh cases l-p.)
 
 Uses only Python stdlib — no PyYAML required.
 """
@@ -99,6 +107,10 @@ STACK_RECONCILE_CONTAINER_NAME = "stack-reconcile"
 # The host docker socket the watchdog talks to. Without this bind-mount the
 # watchdog cannot reach the daemon to revive orphaned containers.
 STACK_RECONCILE_SOCKET_MOUNT = "/var/run/docker.sock:/var/run/docker.sock"
+
+STACK_RECONCILE_CRON_WRAPPER = (
+    f"{ROLES_DIR}/stack_reconcile/templates/stack_reconcile_cron.sh.j2"
+)
 
 # The reconcile script filename — the watchdog command/volumes must reference
 # it (it is mounted in and run on every loop).
@@ -737,6 +749,92 @@ def check_l_reconcile_safety(errors):
             )
 
 
+def check_m_netns_reconcile(errors):
+    """Check M: the netns reconcile (#148) is plumbed end-to-end.
+
+    2026-07-05 incident: autoheal restarted the tailscale-gitea sidecar,
+    which created a NEW network namespace — but gitea (network_mode:
+    container:tailscale-gitea) stayed pinned in the OLD one. tailscale serve
+    dialed 127.0.0.1:3000 in the new netns and got connection refused (502)
+    for ~3.5h while every container, gitea included, reported healthy (its
+    healthcheck runs inside the stranded netns, where localhost answers).
+    restart=always, autoheal, and reconcile steps 1-3 (check K/L) all miss
+    this state; only the StartedAt-comparison step catches it.
+
+    The step is only alive if THREE places agree, and losing any one of them
+    disables it silently (the script defaults NETNS_* to empty and skips):
+      1. the reconcile script implements it (env consumed + StartedAt read);
+      2. the watchdog container passes RECONCILE_NETNS_PARENT/CHILD in env:;
+      3. the cron wrapper sets AND exports both (a set without export never
+         reaches the script's environment).
+    Script BEHAVIOR (guards, idempotency) is locked by
+    tests/reconcile_selftest.sh cases l-p; this check locks the plumbing.
+    """
+    # --- 1. script implements the netns step -------------------------------
+    try:
+        with open(STACK_RECONCILE_SCRIPT) as fh:
+            script = fh.read()
+    except FileNotFoundError:
+        errors.append(f"{STACK_RECONCILE_SCRIPT}: File not found")
+        script = ""
+    if script:
+        for needle, why in (
+            ("RECONCILE_NETNS_PARENT", "consume the netns parent env var"),
+            ("RECONCILE_NETNS_CHILD", "consume the netns child env var"),
+            (".State.StartedAt", "compare container start times — the only "
+                                 "signal that distinguishes a stranded child "
+                                 "from a healthy one"),
+        ):
+            if needle not in script:
+                errors.append(
+                    f"{STACK_RECONCILE_SCRIPT}: missing '{needle}' — the netns "
+                    f"reconcile step must {why}; without it a sidecar restart "
+                    f"strands gitea in a dead netns (502 with everything "
+                    f"'healthy', issue #148) and nothing self-heals."
+                )
+
+    # --- 2. watchdog container delivers the env ----------------------------
+    try:
+        with open(STACK_RECONCILE_TASKS) as fh:
+            tasks = fh.read()
+    except FileNotFoundError:
+        errors.append(f"{STACK_RECONCILE_TASKS}: File not found")
+        tasks = ""
+    if tasks:
+        for var in ("RECONCILE_NETNS_PARENT", "RECONCILE_NETNS_CHILD"):
+            if var not in tasks:
+                errors.append(
+                    f"{STACK_RECONCILE_TASKS}: watchdog container env: does not "
+                    f"pass {var}; the script defaults it to empty and silently "
+                    f"skips the netns reconcile (#148) in the fast ~30s driver."
+                )
+
+    # --- 3. cron wrapper sets AND exports the env --------------------------
+    try:
+        with open(STACK_RECONCILE_CRON_WRAPPER) as fh:
+            cron = fh.read()
+    except FileNotFoundError:
+        errors.append(f"{STACK_RECONCILE_CRON_WRAPPER}: File not found")
+        cron = ""
+    if cron:
+        for var in ("RECONCILE_NETNS_PARENT", "RECONCILE_NETNS_CHILD"):
+            if not re.search(rf'^{var}=', cron, re.MULTILINE):
+                errors.append(
+                    f"{STACK_RECONCILE_CRON_WRAPPER}: does not set {var}; the "
+                    f"host-cron fallback driver would silently skip the netns "
+                    f"reconcile (#148)."
+                )
+            elif not re.search(
+                rf'^export\b[^\n]*(\\\n[^\n]*)*\b{var}\b', cron, re.MULTILINE
+            ):
+                errors.append(
+                    f"{STACK_RECONCILE_CRON_WRAPPER}: sets {var} but never "
+                    f"exports it — a set without export never reaches the "
+                    f"reconcile script's environment, so the netns step is "
+                    f"disabled in the cron driver."
+                )
+
+
 def main():
     errors = []
     warnings = []
@@ -779,6 +877,10 @@ def main():
     # Run check L: the reconcile safety contract is intact (lock stand-down,
     # trap-released backup lock, live-restore, and lock-path single-source)
     check_l_reconcile_safety(errors)
+
+    # Run check M: the netns reconcile (#148) is plumbed end-to-end
+    # (script step + watchdog env + cron wrapper set/export)
+    check_m_netns_reconcile(errors)
 
     # Report results
     for w in warnings:

--- a/tests/reconcile_selftest.sh
+++ b/tests/reconcile_selftest.sh
@@ -21,6 +21,12 @@
 #   policy != always (exited+aged)        -> NO start (restart-policy load-bearing)
 #   (j) ENSURE self-revive                -> start stack-reconcile
 #   (k) Discord alert                     -> wget stub records a POST
+#   (l) netns child stranded (started before a stable healthy parent)
+#                                         -> restart gitea (exact) + alert
+#   (m) netns child newer than parent     -> NO restart (already rejoined)
+#   (n) netns parent unhealthy            -> NO restart (parent-health load-bearing)
+#   (o) netns parent younger than debounce -> NO restart (stability gate)
+#   (p) netns parent w/o healthcheck      -> restart still happens (health optional)
 #
 # The fake `docker` answers `inspect -f <fmt> <name>` from a per-case state
 # table and records `start`/`restart` invocations to a marker file, so each
@@ -74,6 +80,7 @@ case "$verb" in
       *".State.Status"*)                  field="status" ;;
       *".HostConfig.RestartPolicy.Name"*) field="policy" ;;
       *".State.FinishedAt"*)              field="finished" ;;
+      *".State.StartedAt"*)               field="started" ;;
       *".State.Health"*)                  field="health" ;;
       *)                                   field="unknown" ;;
     esac
@@ -174,7 +181,7 @@ reset_state() {
   # external command), so without this an earlier case's RC_LOCK/RC_GATE would
   # silently leak into later cases. Reset them every case to stay isolated.
   RC_CONTAINERS=""; RC_GATE=""; RC_GATE_DEP=""; RC_LOCK=""; RC_DEBOUNCE=""
-  RC_ENSURE=""; RC_HOOK=""
+  RC_ENSURE=""; RC_HOOK=""; RC_NETNS_PARENT=""; RC_NETNS_CHILD=""
   # Same prefix-leak caveat: DATE_FORCE_BUSYBOX set as a prefix on the
   # run_reconcile function call stays in this shell, so clear it each case.
   DATE_FORCE_BUSYBOX=0
@@ -193,6 +200,14 @@ set_container() {
   # health field mirrors the go-template `{{if .State.Health}}...{{end}}`:
   # empty string when the container has no healthcheck.
   printf '%s' "$health" > "$STATE_DIR/$name.health"
+}
+
+# set_started <name> <rfc3339> — the container's .State.StartedAt. Separate
+# from set_container so the pre-netns cases don't have to grow a 6th
+# positional arg; cases that don't call it leave .started missing, which the
+# stub answers with rc=1/empty (StartedAt unknown -> netns step must skip).
+set_started() {
+  printf '%s' "$2" > "$STATE_DIR/$1.started"
 }
 
 # An RFC3339Nano timestamp `age` seconds in the past, WITH a fractional
@@ -222,6 +237,8 @@ run_reconcile() {
   RECONCILE_ENSURE_CONTAINER="${RC_ENSURE:-}" \
   RECONCILE_LOG="$WORK/reconcile.log" \
   RECONCILE_DISCORD_WEBHOOK="${RC_HOOK:-}" \
+  RECONCILE_NETNS_PARENT="${RC_NETNS_PARENT:-}" \
+  RECONCILE_NETNS_CHILD="${RC_NETNS_CHILD:-}" \
   DATE_FORCE_BUSYBOX="${DATE_FORCE_BUSYBOX:-0}" \
   DOCKER_BIN="docker" \
   sh "$SCRIPT"
@@ -384,6 +401,83 @@ check "(k) Discord alert -> wget POST recorded" \
   "$(wget_posted '[stack_reconcile]')"
 check "(k) Discord alert -> action still taken (start gitea-db)" \
   "$(actions_contain 'start gitea-db')"
+
+# --- (l) netns child stranded -> restart child (exact) + alert -------------
+# Root cause of #148: gitea shares the sidecar's netns via network_mode:
+# container:. A sidecar restart creates a NEW netns while gitea's process stays
+# pinned in the OLD one — gitea keeps reporting healthy (its healthcheck runs
+# in the stranded netns) so nothing else ever fixes it. The reconcile must
+# restart the child when it STARTED BEFORE a stable, healthy parent.
+reset_state
+set_container tailscale-gitea running always "-" healthy
+set_started   tailscale-gitea "$(ago 600)"     # parent up 600s > debounce 90s
+set_container gitea-db        running always "-" healthy
+set_container gitea           running always "-" healthy
+set_started   gitea           "$(ago 9000)"    # child predates parent restart
+RC_CONTAINERS="tailscale-gitea gitea-db gitea" \
+RC_NETNS_PARENT="tailscale-gitea" RC_NETNS_CHILD="gitea" \
+RC_HOOK="http://discord.invalid/webhook" RC_DEBOUNCE=90 run_reconcile
+check "(l) netns stranded child -> exactly 'restart gitea'" \
+  "$(actions_exact 'restart gitea')"
+check "(l) netns stranded child -> Discord alert posted" \
+  "$(wget_posted '[stack_reconcile]')"
+
+# --- (m) netns child newer than parent -> NO restart ------------------------
+reset_state
+# Child was (re)started AFTER the parent — it lives in the parent's current
+# netns. Restarting it again every loop would be a thrash loop; must no-op.
+set_container tailscale-gitea running always "-" healthy
+set_started   tailscale-gitea "$(ago 600)"
+set_container gitea-db        running always "-" healthy
+set_container gitea           running always "-" healthy
+set_started   gitea           "$(ago 300)"     # child newer than parent
+RC_CONTAINERS="tailscale-gitea gitea-db gitea" \
+RC_NETNS_PARENT="tailscale-gitea" RC_NETNS_CHILD="gitea" run_reconcile
+check "(m) netns child newer than parent -> NO restart" "$(actions_empty)"
+
+# --- (n) netns parent unhealthy -> NO restart --------------------------------
+reset_state
+# The 2026-07-05 incident: autoheal restart-looped the sidecar for 3h. While
+# the parent is flapping/unhealthy, restarting the child would just thrash it
+# into another doomed netns. The parent-health guard is load-bearing: a mutant
+# ignoring it would restart gitea here and FAIL.
+set_container tailscale-gitea running always "-" unhealthy
+set_started   tailscale-gitea "$(ago 600)"
+set_container gitea-db        running always "-" healthy
+set_container gitea           running always "-" healthy
+set_started   gitea           "$(ago 9000)"
+RC_CONTAINERS="tailscale-gitea gitea-db gitea" \
+RC_NETNS_PARENT="tailscale-gitea" RC_NETNS_CHILD="gitea" run_reconcile
+check "(n) netns parent unhealthy -> NO restart" "$(actions_empty)"
+
+# --- (o) netns parent younger than debounce -> NO restart --------------------
+reset_state
+# Parent restarted moments ago (possibly mid-flap). Wait for it to prove
+# stable (up >= debounce) before committing the child to its netns.
+set_container tailscale-gitea running always "-" healthy
+set_started   tailscale-gitea "$(ago 10)"      # 10s < debounce 90s
+set_container gitea-db        running always "-" healthy
+set_container gitea           running always "-" healthy
+set_started   gitea           "$(ago 9000)"
+RC_CONTAINERS="tailscale-gitea gitea-db gitea" \
+RC_NETNS_PARENT="tailscale-gitea" RC_NETNS_CHILD="gitea" \
+RC_DEBOUNCE=90 run_reconcile
+check "(o) netns parent younger than debounce -> NO restart" "$(actions_empty)"
+
+# --- (p) netns parent without healthcheck -> restart still happens -----------
+reset_state
+# A parent with NO healthcheck (empty .State.Health) must not disable the
+# netns reconcile — health is an extra guard when present, not a requirement.
+set_container tailscale-gitea running always "-" ""
+set_started   tailscale-gitea "$(ago 600)"
+set_container gitea-db        running always "-" healthy
+set_container gitea           running always "-" healthy
+set_started   gitea           "$(ago 9000)"
+RC_CONTAINERS="tailscale-gitea gitea-db gitea" \
+RC_NETNS_PARENT="tailscale-gitea" RC_NETNS_CHILD="gitea" \
+RC_DEBOUNCE=90 run_reconcile
+check "(p) netns parent w/o healthcheck -> exactly 'restart gitea'" \
+  "$(actions_exact 'restart gitea')"
 
 # --- summary ---------------------------------------------------------------
 TOTAL=$(( PASS + FAIL ))

--- a/tests/test-regression.yml
+++ b/tests/test-regression.yml
@@ -35,6 +35,21 @@
       changed_when: false
 
     # ================================================================
+    # Check 1b: reconcile script behavioral self-test
+    # ================================================================
+    # Renders stack_reconcile.sh.j2 and exercises every reconcile case
+    # against a stubbed docker/date/wget (no daemon, no network): lock
+    # stand-down, debounce, dependency gate, ENSURE self-revive, Discord
+    # alert, and the #148 netns reconcile (stranded-child restart + its
+    # parent-health / stability / idempotency guards). check_docker_tasks
+    # CHECK M locks the netns env PLUMBING; this locks the BEHAVIOR.
+    - name: "CHECK 1b: Run the stack_reconcile behavioral self-test"
+      command: bash {{ project_root }}/tests/reconcile_selftest.sh
+      args:
+        chdir: "{{ project_root }}"
+      changed_when: false
+
+    # ================================================================
     # Check 2: No hardcoded /volume1/ paths in roles (Gap 3)
     # ================================================================
     - name: "CHECK 2: Scan role tasks for hardcoded /volume1/ paths"


### PR DESCRIPTION
## Summary

Fixes #148 — the 2026-07-05 outage where a `tailscale-gitea` restart (autoheal, acting on a failing dns-watchdog healthcheck) stranded `gitea` in a dead network namespace: external **502 for ~3.5h while every container reported `Up (healthy)`**, because gitea's healthcheck runs inside the stranded netns where `localhost:3000` still answers. No existing mechanism (`restart=always`, autoheal, reconcile steps 1–3) can see this state.

## What changed

- **`stack_reconcile.sh` step 4 (netns reconcile):** if the netns child (`gitea`) is running but its `StartedAt` predates the netns parent's (`tailscale-gitea`), restart the child so it rejoins the parent's current namespace. Guards:
  - both running (step 2 revives stopped containers first)
  - parent healthy — or has no healthcheck; a flapping/unhealthy parent (the incident's autoheal loop) must stabilize first, or we'd thrash the child into another doomed netns
  - parent up ≥ debounce (90s) — a mid-flap parent gets time to prove stable
  - skip on unparseable `StartedAt` (restarting a fine child is an outage; opposite trade-off from the step-2 age-unknown branch, where a dead orphan left dead is worse)
  - naturally idempotent: the restart makes the child newer than the parent — one restart per parent restart, never a loop
- **Env plumbing:** `RECONCILE_NETNS_PARENT`/`RECONCILE_NETNS_CHILD` delivered by BOTH drivers — the watchdog container `env:` and the cron wrapper (set + export) — with role defaults `tailscale-gitea`/`gitea` and meta arg-spec docs.
- **Regression locks:**
  - `check_docker_tasks.py` **CHECK M** locks the plumbing end-to-end (script step + watchdog env + cron set/export). Mutant-verified: deleting any of the three plumbing points trips it.
  - `reconcile_selftest.sh` **cases (l)–(p)** lock the behavior (stranded→restart+alert; newer-child, unhealthy-parent, young-parent → no-op; parent without healthcheck still acts). Written TDD — (l)/(p) observed failing before the script change.
  - **CHECK 1b:** wired the previously CI-orphaned `reconcile_selftest.sh` into `test-regression.yml`, so all 23 behavioral cases now run in CI.
- **Runbook:** documented step 5 and the manual stranded-namespace recovery (`docker restart gitea` after confirming with `docker exec tailscale-gitea wget http://127.0.0.1:3000/`).

## Test plan

- [x] `bash tests/reconcile_selftest.sh` — 23/23 cases pass (new netns cases failed RED before the fix)
- [x] `python3 tests/check_docker_tasks.py` — passes; CHECK M mutant-tested against all three plumbing removals
- [x] `ansible-playbook tests/test-regression.yml` — full suite green (ok=81 failed=0), including new CHECK 1b

## Related

- Companion issue for the amplification half (dns-watchdog exit 1 + autoheal restart loop): jaxzin/ansible-collection-infra#12
- Incident recovery already performed manually on the NAS (`docker restart gitea`); Gitea is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)